### PR TITLE
Version bump (1.0.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Yes, the plugin uses a modular architecture where individual modules can be enab
 
 ### How can I get more information on how to use the plugin?
 
-You can use the chatbot at [https://deepwiki.com/a8cteam51/a8csp-atlantis](https://deepwiki.com/a8cteam51/a8csp-atlantis) for extensive help related to usablity, plugin structure, and development.
+You can use the chatbot at [https://deepwiki.com/a8cteam51/a8csp-atlantis](https://deepwiki.com/a8cteam51/a8csp-atlantis) for extensive help related to usability, plugin structure, and development.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - **Requires at least:** 6.5
 - **Tested up to:** 6.8.1
 - **Requires PHP:** 8.3
-- **Stable tag:** 1.0.1
+- **Stable tag:** 1.0.2
 - **License:** GPLv3 or later
 - **License URI:** [http://www.gnu.org/licenses/gpl-3.0.html](http://www.gnu.org/licenses/gpl-3.0.html)
 

--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -3,7 +3,7 @@
  * The A8CSP Atlantic bootstrap file.
  *
  * @since       1.0.0
- * @version     1.0.1
+ * @version     1.0.2
  * @package     A8C\SpecialProjects\Plugins
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
@@ -15,7 +15,7 @@
  * Plugin URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Update URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Description:             Atlantis.
- * Version:                 1.0.1
+ * Version:                 1.0.2
  * Requires at least:       6.8
  * Tested up to:            6.8.1
  * Requires PHP:            8.1

--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The A8CSP Atlantic bootstrap file.
+ * The A8CSP Atlantis bootstrap file.
  *
  * @since       1.0.0
  * @version     1.0.2
@@ -18,7 +18,7 @@
  * Version:                 1.0.2
  * Requires at least:       6.8
  * Tested up to:            6.8.1
- * Requires PHP:            8.1
+ * Requires PHP:            8.3
  * Author:                  Automattic Special Projects
  * Author URI:              https://specialprojects.automattic.com
  * License:                 GPL v3 or later

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a8csp-atlantis",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A scaffold for A8C Special Projects plugins",
   "author": {
     "name": "A8C Special Projects Team",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bumped the version of the plugin to 1.0.2 to create a new release and test its self-update functionality.

#### Testing instructions

* Install the v.1.0.1 version of the plugin to any site
* Confirm that the new version (1.0.2) appears as a new update
* Confirm that the plugin gets self-updated.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated README: Stable tag set to 1.0.2 and corrected two "usability" typos in usage guidance.
- Chores
  - Bumped project and package version metadata to 1.0.2 for consistency.
  - Updated minimum PHP requirement to 8.3.
  - No functional changes; behavior and APIs remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->