### PR TITLE
Add activation hook to disable autoupdates if legacy filter is inactive

### DIFF
--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -36,6 +36,7 @@ define( 'A8CSP_ATLANTIS_DIR_URL', plugin_dir_url( __FILE__ ) );
 
 // Load the rest of the bootstrap functions.
 require_once A8CSP_ATLANTIS_DIR_PATH . '/functions-bootstrap.php';
+register_activation_hook( __FILE__, 'a8csp_atlantis_maybe_disable_autoupdates_module_on_activation' );
 
 // Load plugin translations so they are available even for the error admin notices.
 add_action(

--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -3,7 +3,7 @@
  * The A8CSP Atlantis bootstrap file.
  *
  * @since       1.0.0
- * @version     1.0.3
+ * @version     1.0.4
  * @package     A8C\SpecialProjects\Plugins
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
@@ -15,7 +15,7 @@
  * Plugin URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Update URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Description:             Centralized site management for Team51.
- * Version:                 1.0.3
+ * Version:                 1.0.4
  * Requires at least:       6.8
  * Tested up to:            6.8.1
  * Requires PHP:            8.3

--- a/functions-bootstrap.php
+++ b/functions-bootstrap.php
@@ -196,3 +196,62 @@ function a8csp_atlantis_output_requirements_error( $error ) {
 		}
 	);
 }
+
+/**
+ * Checks whether the legacy Plugin Autoupdate Filter plugin is active.
+ *
+ * @return bool
+ */
+function a8csp_atlantis_is_legacy_autoupdate_filter_active(): bool {
+	if ( ! function_exists( 'get_plugins' ) ) {
+		/* @phpstan-ignore requireOnce.fileNotFound */
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	if ( ! function_exists( 'is_plugin_active' ) ) {
+		/* @phpstan-ignore requireOnce.fileNotFound */
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	$plugin_file = 'plugin-autoupdate-filter/plugin-autoupdate-filter.php';
+	$plugins     = get_plugins();
+
+	if ( ! isset( $plugins[ $plugin_file ] ) ) {
+		return false;
+	}
+
+	if ( is_plugin_active( $plugin_file ) ) {
+		return true;
+	}
+
+	return is_multisite() && is_plugin_active_for_network( $plugin_file );
+}
+
+/**
+ * On Atlantis activation, disable the Autoupdates module when legacy PAF is not active.
+ *
+ * @return void
+ */
+function a8csp_atlantis_maybe_disable_autoupdates_module_on_activation(): void {
+	if ( ! function_exists( 'get_plugins' ) ) {
+		/* @phpstan-ignore requireOnce.fileNotFound */
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	$plugin_file = 'plugin-autoupdate-filter/plugin-autoupdate-filter.php';
+	$plugins     = get_plugins();
+	if ( ! isset( $plugins[ $plugin_file ] ) ) {
+		return;
+	}
+
+	if ( a8csp_atlantis_is_legacy_autoupdate_filter_active() ) {
+		return;
+	}
+
+	$option_key       = a8csp_atlantis_generate_module_settings_key( 'Autoupdates' );
+	$current_settings = get_option( $option_key, array() );
+	$module_settings  = is_array( $current_settings ) ? $current_settings : array();
+
+	$module_settings['enabled'] = '0';
+	update_option( $option_key, $module_settings );
+}

--- a/src/Modules/Autoupdates/PluginFilterAdminUI.php
+++ b/src/Modules/Autoupdates/PluginFilterAdminUI.php
@@ -15,8 +15,8 @@ class PluginFilterAdminUI {
 	/**
 	 * Customize automatic update setting HTML for plugins page in wp-admin.
 	 *
-	 * @param string $html        HTML for automatic update settings.
-	 * @param string $plugin_file Path to plugin file.
+	 * @param string               $html        HTML for automatic update settings.
+	 * @param string               $plugin_file Path to plugin file.
 	 * @param array<string, mixed> $plugin_data Plugin data for the current row.
 	 *
 	 * @return string Customized HTML for automatic update settings.


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Add activation-time safeguard for legacy migration behavior:
  * On Atlantis activation, check whether legacy `plugin-autoupdate-filter/plugin-autoupdate-filter.php` is installed.
  * Only if installed **and inactive**, disable Atlantis `Autoupdates` module.
  * If legacy plugin is not installed, leave Atlantis module settings unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced plugin activation with automated autoupdates module management. The system now intelligently detects legacy autoupdate configurations and automatically adjusts module settings on activation to ensure improved compatibility and seamless integration.

* **Chores**
  * Version updated to 1.0.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->