### PR TITLE
Add Atlantis agent context and module-specific skills

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,44 @@
+# .agents — Atlantis Plugin Agent Skills
+
+This folder contains plugin-specific skills for AI coding assistants working on the Atlantis WordPress plugin.
+
+## Structure
+
+```text
+.agents/
+├── README.md
+└── skills/
+    ├── atlantis-architecture/SKILL.md  ← Plugin internals, modules, bootstrap, settings model
+    ├── atlantis-autoupdates/SKILL.md   ← Autoupdates rules, PAF compatibility, per-plugin toggles
+    ├── atlantis-messages/SKILL.md      ← Messages CRUD, storage, list table flows
+    ├── atlantis-tracking/SKILL.md      ← Tracking integrations and env gates
+    ├── atlantis-colophon/SKILL.md      ← Credits rendering and shortcode behavior
+    └── atlantis-testing/SKILL.md       ← Integration tests, CI workflows, npm/composer consistency
+```
+
+## Which Skill to Use
+
+| Task | Skill |
+| ------ | ------- |
+| Working on Atlantis core/plugin architecture or module lifecycle | `atlantis-architecture` |
+| Changing auto-update behavior or admin toggle logic | `atlantis-autoupdates` |
+| Changing Messages module data/UI behavior | `atlantis-messages` |
+| Changing Tracking integrations or environment behavior | `atlantis-tracking` |
+| Changing Colophon output or shortcode behavior | `atlantis-colophon` |
+| Writing/running tests or fixing CI/lint failures | `atlantis-testing` |
+
+## Recommended: WordPress Agent-Skills
+
+This plugin also benefits from the community [WordPress/agent-skills](https://github.com/WordPress/agent-skills). These are not bundled:
+
+| Skill | Relevance |
+| ------- | ----------- |
+| `wp-plugin-development` | Plugin architecture, hooks, activation, settings, security. |
+| `wp-block-development` | Gutenberg-related patterns if Atlantis block integrations are added. |
+| `wp-rest-api` | REST conventions when adding endpoints. |
+| `wp-performance` | Profiling and optimization. |
+| `wp-wpcli-and-ops` | WP-CLI operations and automation. |
+| `wp-playground` | Local development flows. |
+| `wp-phpstan` | Static analysis setup and fixes. |
+| `wordpress-router` | Repo classification and workflow routing. |
+| `wp-project-triage` | Project/tooling detection. |

--- a/.agents/skills/atlantis-architecture/SKILL.md
+++ b/.agents/skills/atlantis-architecture/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: atlantis-architecture
+description: Guides work on Atlantis plugin PHP architecture including bootstrap flow, module lifecycle, settings model, and activation behavior. Use when adding/changing modules, plugin initialization, or shared helper patterns.
+---
+
+# Skill: Atlantis Plugin Architecture
+
+## When to Use
+
+Use this skill when:
+- Adding or modifying modules in `src/Modules/`.
+- Changing plugin bootstrap/initialization flow.
+- Updating module settings behavior in `AbstractModule`.
+- Adding compatibility logic during activation.
+
+## Bootstrap Flow
+
+1. `a8csp-atlantis.php` defines constants and loads `functions-bootstrap.php`.
+2. Activation hook is registered for activation-time compatibility checks.
+3. `functions.php` loads `includes/*.php` helper files.
+4. `plugins_loaded` triggers `a8csp_atlantis_get_plugin_instance()->maybe_initialize()`.
+5. `Plugin::initialize()` wires `Encryption`, `Modules`, and `Settings`.
+
+## Module Pattern
+
+Atlantis modules follow `AbstractModule`:
+
+- `is_active()` reads `a8csp_module_{slug}` settings (`enabled` flag).
+- `maybe_initialize()` returns early if module is disabled.
+- `initialize()` registers module runtime hooks only when active.
+- Default module setting is created via `maybe_set_default_settings()`.
+
+Current module registry:
+- `messages`
+- `colophon`
+- `tracking`
+- `autoupdates`
+
+## Settings Model
+
+- Module option key helper: `a8csp_atlantis_generate_module_settings_key()`.
+- Module settings getter: `a8csp_atlantis_get_module_settings()`.
+- Admin menus are restricted to probable Automatticians (`a8csp_atlantis_is_automattician()`).
+
+## Activation Compatibility Behavior
+
+Activation hook currently performs legacy PAF compatibility checks:
+- If `plugin-autoupdate-filter/plugin-autoupdate-filter.php` is installed and inactive, Atlantis disables the Autoupdates module.
+- If not installed, Atlantis leaves module settings unchanged.
+
+## Procedure: Adding a New Module
+
+1. Create module class in `src/Modules/{ModuleName}/`.
+2. Extend `AbstractModule` and implement `get_name()`, `get_description()`, `initialize()`.
+3. Register module in `src/Modules.php`.
+4. Add helper wrappers under `includes/module-{name}.php` if needed.
+5. Add `tests/Integration/{ModuleName}TestCest.php`.
+
+## Verification
+
+- `composer run lint:php`
+- `composer run tests:run:integration`
+- Validate module can be toggled in Atlantis Modules settings.

--- a/.agents/skills/atlantis-autoupdates/SKILL.md
+++ b/.agents/skills/atlantis-autoupdates/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: atlantis-autoupdates
+description: Guides Autoupdates module work including schedule windows, rollout delays, per-plugin filter toggles, and legacy Plugin Autoupdate Filter compatibility. Use when changing autoupdate behavior or related admin UI.
+---
+
+# Skill: Atlantis Autoupdates
+
+## When to Use
+
+Use this skill when:
+- Working in `src/Modules/Autoupdates/*`.
+- Updating `auto_update_plugin` / `auto_update_core` behavior.
+- Changing per-plugin PAF toggle behavior in wp-admin.
+- Adjusting centralized settings or delay cleanup logic.
+
+## Main Components
+
+| File | Responsibility |
+|------|----------------|
+| `AutoUpdatePluginsFilter.php` | Core hooks and autoupdate decision pipeline. |
+| `PluginFilterAdminUI.php` | Plugins-screen UI for per-plugin enable/disable of Atlantis filter rules. |
+| `PluginFilterRules.php` | Shared source of truth for disabled plugin list and external callback checks. |
+| `Helpers.php` | Delay tracking and cleanup helpers. |
+
+## Key Behaviors
+
+- Uses time/day windows to determine update eligibility.
+- Supports temporary no-update holiday windows.
+- Adds staged delay behavior per plugin version.
+- Supports per-plugin bypass via site option `plugin_autoupdate_filter_disabled_plugins`.
+- If external `disable_autoupdate_specific_plugins` exists, Atlantis respects it in UI messaging.
+
+## Guardrails
+
+- Preserve hook priorities and accepted arg counts.
+- Keep shared logic centralized in `PluginFilterRules` (avoid duplicate methods).
+- Make user-facing admin text translatable and escaped.
+- Do not register autoupdate hooks when module is disabled.
+
+## Procedure: Changing Filter Logic
+
+1. Update shared rule helpers first (`PluginFilterRules`) when logic is cross-class.
+2. Update runtime class (`AutoUpdatePluginsFilter`) behavior.
+3. Update admin UI class for visibility/toggle behavior if user-facing behavior changes.
+4. Update integration tests (`AutoupdatesTestCest`) and restore mutated options in `finally`.
+
+## Verification
+
+- `composer run lint:php:phpstan`
+- `composer run tests:run:integration`
+- Manual test on Plugins screen: toggle PAF updates and verify admin notice + setting HTML.

--- a/.agents/skills/atlantis-colophon/SKILL.md
+++ b/.agents/skills/atlantis-colophon/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: atlantis-colophon
+description: Guides work on Atlantis Colophon module, including credits rendering, shortcodes, and customization filters.
+---
+
+# Skill: Atlantis Colophon Module
+
+## When to Use
+
+Use this skill when:
+
+- Working in `src/Modules/Colophon/*`.
+- Updating `includes/module-colophon.php`.
+- Changing credits output or shortcode behavior.
+
+## Main Components
+
+| File | Responsibility |
+| ------ | ---------------- |
+| `src/Modules/Colophon/Colophon.php` | Module registration and lifecycle hooks. |
+| `includes/module-colophon.php` | Core rendering, action handler, and shortcode callbacks. |
+| `src/Modules/Colophon/README.md` | Usage patterns and customization examples. |
+
+## Guardrails
+
+- Preserve action and shortcode contracts (`team51_credits`, `team51-credits`, `team51-current-year`).
+- Keep output safely escaped and translatable where user-facing text changes.
+- Ensure output buffering returns content and does not double-echo.
+
+## Procedure
+
+1. Update rendering logic and/or shortcode behavior.
+2. Validate action and shortcode parity for equivalent options.
+3. Update `tests/Integration/ColophonTestCest.php` for behavioral changes.
+
+## Verification
+
+- `composer run lint:php`
+- `composer run tests:run:integration`

--- a/.agents/skills/atlantis-messages/SKILL.md
+++ b/.agents/skills/atlantis-messages/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: atlantis-messages
+description: Guides work on Atlantis Messages module, including CRUD, storage, admin list/form flows, and location-based notice rendering.
+---
+
+# Skill: Atlantis Messages Module
+
+## When to Use
+
+Use this skill when:
+
+- Working in `src/Modules/Messages/*`.
+- Updating helpers in `includes/module-messages.php`.
+- Changing message CRUD, status transitions, or rendering logic.
+
+## Main Components
+
+| File | Responsibility |
+| ------ | ---------------- |
+| `src/Modules/Messages/Messages.php` | Module hooks, admin integrations, and orchestration. |
+| `src/Modules/Messages/CustomTable.php` | DB schema and custom table lifecycle. |
+| `src/Modules/Messages/ListTable.php` | Admin list table actions and UI flow. |
+| `includes/module-messages.php` | Public helper APIs for CRUD and retrieval. |
+| `models/Message.php`, `models/Message_Query.php` | Message model and query behavior. |
+
+## Guardrails
+
+- Use `$wpdb` with proper formats/placeholders for DB writes.
+- Keep message helper API signatures backward compatible.
+- Sanitize admin inputs and escape output.
+- Preserve status semantics (`active`/`inactive`) and location filters.
+
+## Procedure
+
+1. Implement data/schema or logic changes in module classes.
+2. Update helper wrappers in `includes/module-messages.php` if API behavior changes.
+3. Update integration tests in `tests/Integration/MessagesTestCest.php`.
+4. Validate no cross-test option/table state leakage.
+
+## Verification
+
+- `composer run lint:php`
+- `composer run tests:run:integration`

--- a/.agents/skills/atlantis-testing/SKILL.md
+++ b/.agents/skills/atlantis-testing/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: atlantis-testing
+description: Guides writing/running Atlantis tests and fixing CI issues across Codeception integration tests, PHP QA tools, and npm/composer workflow stability.
+---
+
+# Skill: Atlantis Testing
+
+## When to Use
+
+Use this skill when:
+- Writing or modifying integration tests in `tests/Integration/`.
+- Debugging CI failures (`phpcs`, `phpmd`, `phpstan`, `npm ci`, Codeception).
+- Updating GitHub workflow behavior.
+
+## Test & QA Stack
+
+| Area | Command |
+|------|---------|
+| PHP lint stack | `composer run lint:php` |
+| PHPStan only | `composer run lint:php:phpstan` |
+| Integration tests | `composer run tests:run:integration` |
+| Full tests | `npm run tests:run` |
+
+## Current Test Convention
+
+- Integration tests use Codeception Cest format.
+- File naming: `tests/Integration/*TestCest.php`.
+- Use `PHPUnit\Framework\Assert` static assertions.
+- Restore modified options/state in tests to avoid leakage.
+
+## CI Workflow Guidance
+
+- Workflows running `npm ci` should pin Node major version for stability.
+- Lockfile drift issues often come from running old SHA or runtime mismatch.
+- Ensure `package-lock.json` is regenerated consistently when needed.
+
+## Procedure: Adding/Changing Tests
+
+1. Add or update module-specific Cest test.
+2. Cover primary behavior + edge cases + option cleanup.
+3. Run local integration tests and lint.
+4. If CI fails, verify workflow runtime and commit SHA before changing code.
+
+## Verification
+
+- `composer run lint:php`
+- `composer run tests:run:integration`
+- If workflow changed, re-run affected GitHub checks.

--- a/.agents/skills/atlantis-tracking/SKILL.md
+++ b/.agents/skills/atlantis-tracking/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: atlantis-tracking
+description: Guides work on Atlantis Tracking module for WooCommerce, Sensei, and Bilmur integrations, including environment-based activation behavior.
+---
+
+# Skill: Atlantis Tracking Module
+
+## When to Use
+
+Use this skill when:
+
+- Working in `src/Modules/Tracking/*`.
+- Changing tracking defaults or integration enable/disable behavior.
+- Adjusting environment gates for development/staging/local.
+
+## Main Components
+
+| File | Responsibility |
+| ------ | ---------------- |
+| `src/Modules/Tracking/Tracking.php` | Module orchestration and environment checks. |
+| `src/Modules/Tracking/Integrations/WooCommerce.php` | WooCommerce tracking integration behavior. |
+| `src/Modules/Tracking/Integrations/Sensei.php` | Sensei tracking integration behavior. |
+| `src/Modules/Tracking/Integrations/Bilmur.php` | Bilmur RUM integration and script behavior. |
+
+## Guardrails
+
+- Keep non-production environment disable behavior intact unless explicitly changed.
+- Preserve existing constant-based feature toggles.
+- Avoid regressions in default opt-in behavior for integrations.
+
+## Procedure
+
+1. Update module or specific integration class.
+2. Validate constant gates and environment checks.
+3. Update `tests/Integration/TrackingTestCest.php` for behavior changes.
+
+## Verification
+
+- `composer run lint:php`
+- `composer run tests:run:integration`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,147 @@
+# Atlantis WordPress Plugin — Agent Instructions
+
+This file provides AI coding assistants with the context they need to work effectively on the Atlantis WordPress plugin.
+
+## Plugin Overview
+
+**Atlantis** (`a8csp-atlantis`) is a modular operational plugin for partner sites. It provides:
+
+- A module framework with per-module enable/disable settings.
+- Messages management with custom DB-backed admin notifications.
+- Auto-update control (timing windows, rollout delays, centralized settings, per-plugin filter toggles).
+- Tracking integrations (WooCommerce, Sensei, Bilmur).
+- Colophon utilities (credits action + shortcodes).
+
+**Text domain:** `a8csp-atlantis`  
+**Namespace:** `A8C\SpecialProjects\Atlantis\`  
+**Requires:** WordPress 6.8+, PHP 8.3+
+
+---
+
+## Directory Structure
+
+```text
+a8csp-atlantis/
+├── a8csp-atlantis.php            ← Bootstrap and activation hook registration
+├── functions-bootstrap.php       ← Bootstrap helpers and activation-time compatibility logic
+├── functions.php                 ← Loads include helper files
+├── AGENTS.md                     ← You are here
+├── CLAUDE.md                     ← Points to this file
+├── .agents/
+│   ├── README.md
+│   └── skills/
+│       ├── atlantis-architecture/SKILL.md
+│       ├── atlantis-autoupdates/SKILL.md
+│       ├── atlantis-messages/SKILL.md
+│       ├── atlantis-tracking/SKILL.md
+│       ├── atlantis-colophon/SKILL.md
+│       └── atlantis-testing/SKILL.md
+│
+├── includes/                     ← Global helper wrappers and utility functions
+│   ├── module-messages.php
+│   ├── module-colophon.php
+│   ├── module-tracking.php
+│   ├── module-autoupdates.php
+│   ├── settings.php
+│   ├── encryption.php
+│   └── miscellaneous.php
+│
+├── src/
+│   ├── Plugin.php                ← Main singleton
+│   ├── Modules.php               ← Module registry
+│   ├── Settings.php              ← Admin menu and settings pages
+│   ├── Encryption.php            ← Encryption setup helpers
+│   └── Modules/
+│       ├── AbstractModule.php    ← Module lifecycle/settings base class
+│       ├── Messages/
+│       ├── Autoupdates/
+│       ├── Tracking/
+│       └── Colophon/
+│
+└── tests/Integration/            ← Module and core integration Cest tests
+```
+
+---
+
+## Architecture
+
+### Bootstrap
+
+`a8csp-atlantis.php` loads bootstrap helpers and plugin entry points, then initializes on `plugins_loaded` through `Plugin::get_instance()->maybe_initialize()`.
+
+### Module Lifecycle
+
+All modules extend `AbstractModule`:
+
+- settings key generation via `a8csp_atlantis_generate_module_settings_key()`
+- active/disabled checks in `is_active()` and `is_disabled()`
+- runtime hook registration only in `initialize()` after `maybe_initialize()` gates
+
+### Activation Compatibility
+
+On activation, Atlantis checks legacy `plugin-autoupdate-filter` state:
+
+- if legacy plugin is installed and inactive -> disable Atlantis Autoupdates module
+- if legacy plugin is active or not installed -> leave module settings unchanged
+
+---
+
+## Coding Standards
+
+- Follow WordPress PHP coding standards used in this repository.
+- Use tabs for indentation.
+- Sanitize input and escape output.
+- Use strict comparisons (`===`, `!==`) and Yoda conditions.
+- Keep module behavior behind module activation checks.
+
+---
+
+## Development Workflows
+
+```bash
+# Install dependencies
+composer install
+npm install
+
+# PHP quality checks
+composer run lint:php
+
+# PHPStan only
+composer run lint:php:phpstan
+
+# Integration tests
+composer run tests:run:integration
+
+# Full test run
+npm run tests:run
+```
+
+---
+
+## Skills
+
+Plugin-specific skills are in `.agents/skills/`:
+
+| Skill | When to Use |
+| ------- | ------------- |
+| `atlantis-architecture` | Plugin internals, module lifecycle, bootstrap, settings model. |
+| `atlantis-autoupdates` | Autoupdate filter behavior, admin toggle UI, PAF compatibility. |
+| `atlantis-messages` | Messages CRUD, storage model, list table/admin flows. |
+| `atlantis-tracking` | Tracking integration behavior and environment gates. |
+| `atlantis-colophon` | Credits rendering, actions, and shortcode behavior. |
+| `atlantis-testing` | Integration tests, lint/CI failures, workflow stability. |
+
+See `.agents/README.md` for structure and routing guidance.
+
+---
+
+## AGENTS.md Maintenance Rule
+
+Update this file when a change affects agent decision-making, including:
+
+- Plugin/bootstrap architecture or module lifecycle behavior.
+- Module inventory, responsibilities, or integration boundaries.
+- Development workflows (lint/test/build/CI commands).
+- Project-specific coding constraints or guardrails.
+
+Do not update this file for minor bug fixes or refactors that do not change architecture, workflows, or guidance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add agent guidance docs at plugin root:
  * `AGENTS.md` with Atlantis architecture, workflows, and maintenance rules.
  * `CLAUDE.md` pointing to `@AGENTS.md`.
* Add `.agents` documentation and skill structure aligned to the reference pattern:
  * `.agents/README.md`
  * `.agents/skills/<skill-name>/SKILL.md`
* Add plugin/module-specific skills:
  * `atlantis-architecture`
  * `atlantis-autoupdates`
  * `atlantis-messages`
  * `atlantis-tracking`
  * `atlantis-colophon`
  * `atlantis-testing`
* Document routing guidance so agents can pick the right skill by task area.

#### Testing instructions

* Confirm new files exist and are structured correctly:
  * `AGENTS.md`, `CLAUDE.md`
  * `.agents/README.md`
  * `.agents/skills/*/SKILL.md`
* Verify `CLAUDE.md` contains exactly `@AGENTS.md`.
* Review `AGENTS.md` and `.agents/README.md` links/paths to ensure they resolve to existing skill files.
* Run markdown lint/checks if available and confirm no formatting errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added comprehensive development documentation suite covering plugin architecture, module lifecycle, testing procedures, and maintenance workflows.
* Included detailed guides for specific modules including autoupdates, tracking, messaging, and colophon functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->