### PR TITLE
Disable autoupdates for specific plugins based on centralized settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - **Requires at least:** 6.5
 - **Tested up to:** 6.8.1
 - **Requires PHP:** 8.3
-- **Stable tag:** 1.0.3
+- **Stable tag:** 1.0.5
 - **License:** GPLv3 or later
 - **License URI:** [http://www.gnu.org/licenses/gpl-3.0.html](http://www.gnu.org/licenses/gpl-3.0.html)
 
@@ -24,6 +24,18 @@ A collection of utilities developed by the WordPress Special Projects team for m
 - **Colophon**: Footer attribution system for site credits ([Readme](./src/Modules/Colophon/README.md))
   
 The plugin uses a modular architecture where individual modules can be enabled or disabled through the WordPress admin interface.  
+
+### Centralized autoupdate settings
+
+The Autoupdates module reads centralized settings from:
+
+- `https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/autoupdate-plugin/v1/settings/`
+
+The payload supports:
+
+- `disable_all` to block all automatic updates.
+- `canary_sites` to bypass delay logic on selected sites.
+- `disabled_plugins` to block automatic updates for specific plugins across connected sites.
 
 ## Installation
 

--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -3,7 +3,7 @@
  * The A8CSP Atlantis bootstrap file.
  *
  * @since       1.0.0
- * @version     1.0.4
+ * @version     1.0.5
  * @package     A8C\SpecialProjects\Plugins
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
@@ -15,7 +15,7 @@
  * Plugin URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Update URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Description:             Centralized site management for Team51.
- * Version:                 1.0.4
+ * Version:                 1.0.5
  * Requires at least:       6.8
  * Tested up to:            6.8.1
  * Requires PHP:            8.3

--- a/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
+++ b/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
@@ -58,8 +58,6 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 	 * @version 1.0.0
 	 */
 	protected function initialize(): void {
-		$plugin_filter_admin_ui = new PluginFilterAdminUI();
-
 		// get the centralized settings from opsoasis
 		try {
 			$this->settings = $this->get_auto_update_settings();
@@ -74,6 +72,8 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 				}
 			);
 		}
+
+		$plugin_filter_admin_ui = new PluginFilterAdminUI( $this->settings );
 
 		// setup plugins and core to autoupdate _unless_ it's during specific day/time
 		add_filter( 'auto_update_plugin', array( $this, 'filter_auto_update_specific_times' ), 10, 2 );
@@ -102,7 +102,7 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 		add_filter( 'auto_theme_update_send_email', '__return_true', 11 );
 
 		// "Disable all autoupdates" toggle
-		add_filter( 'auto_update_plugin', array( $this, 'filter_maybe_disable_all_autoupdates' ), PHP_INT_MAX );
+		add_filter( 'auto_update_plugin', array( $this, 'filter_maybe_disable_all_autoupdates' ), PHP_INT_MAX, 2 );
 		add_filter( 'auto_update_core', array( $this, 'filter_maybe_disable_all_autoupdates' ), PHP_INT_MAX, 2 );
 		add_filter( 'auto_update_theme', array( $this, 'filter_maybe_disable_all_autoupdates' ), PHP_INT_MAX, 2 );
 		add_action( 'admin_init', array( $this, 'output_auto_updates_disabled_admin_notice' ) );
@@ -125,7 +125,7 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 
 		// Try getting the settings from the transient first
 		$transient_key = 'wpcpmsp_auto_update_settings';
-		$settings      = get_transient( $transient_key );
+		$settings      = [];
 
 		if ( empty( $settings ) ) {
 			$response = wp_safe_remote_get(
@@ -172,11 +172,16 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 	 * If we have hit the "Disable all autoupdates" toggle switch, or if we can't get the centralized settings, don't autoupdate anything.
 	 *
 	 * @param bool|null $update Whether to update the plugin or not. This can be bool or null as per the docs.
+	 * @param object    $item   The update item object.
 	 *
 	 * @return bool True to update, false to not update.
 	 */
-	public function filter_maybe_disable_all_autoupdates( $update ): bool {
+	public function filter_maybe_disable_all_autoupdates( $update, $item = null ): bool {
 		if ( isset( $this->settings->disable_all ) ) {
+			return false;
+		}
+
+		if ( is_object( $item ) && $this->is_plugin_disabled_in_centralized_settings( $item ) ) {
 			return false;
 		}
 
@@ -405,9 +410,8 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 	 * Append text to upgrade text on plugins page for plugins explicitly set to not autoupdate
 	 */
 	public function output_upgrade_message_for_specific_plugins(): void {
-		// check if updates are explicitly blocked for this plugin
 		// don't show if we are already disabling all updates
-		if ( ! function_exists( 'disable_autoupdate_specific_plugins' ) || isset( $this->settings->disable_all ) ) {
+		if ( isset( $this->settings->disable_all ) ) {
 			return;
 		}
 
@@ -418,7 +422,8 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 			$plugin_obj        = new \stdClass();
 			$slug              = dirname( $plugin_file );
 			$plugin_obj->slug  = $slug;
-			$plugin_can_update = PluginFilterRules::is_plugin_allowed_to_autoupdate( $plugin_obj );
+			$plugin_obj->plugin = $plugin_file;
+			$plugin_can_update  = ! PluginFilterRules::is_plugin_blocked_from_autoupdates( $plugin_obj, $this->settings );
 			if ( false === $plugin_can_update ) {
 				// add notice next to the "update now" link
 				add_filter(
@@ -441,6 +446,35 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Check whether centralized settings disable autoupdates for a plugin item.
+	 *
+	 * @param object $item Plugin update item object.
+	 *
+	 * @return bool
+	 */
+	private function is_plugin_disabled_in_centralized_settings( object $item ): bool {
+		if ( isset( $item->theme ) ) {
+			return false;
+		}
+
+		$plugin_obj = new \stdClass();
+
+		if ( isset( $item->plugin ) && is_string( $item->plugin ) ) {
+			$plugin_obj->plugin = $item->plugin;
+		}
+
+		if ( isset( $item->slug ) && is_string( $item->slug ) ) {
+			$plugin_obj->slug = $item->slug;
+		}
+
+		if ( ! isset( $plugin_obj->plugin ) && ! isset( $plugin_obj->slug ) ) {
+			return false;
+		}
+
+		return PluginFilterRules::is_plugin_disabled_by_centralized_settings( $plugin_obj, $this->settings );
 	}
 
 	/**

--- a/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
+++ b/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
@@ -125,7 +125,7 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 
 		// Try getting the settings from the transient first
 		$transient_key = 'wpcpmsp_auto_update_settings';
-		$settings      = [];
+		$settings      = get_transient( $transient_key );
 
 		if ( empty( $settings ) ) {
 			$response = wp_safe_remote_get(

--- a/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
+++ b/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
@@ -177,7 +177,7 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 	 * @return bool True to update, false to not update.
 	 */
 	public function filter_maybe_disable_all_autoupdates( $update, $item = null ): bool {
-		if ( isset( $this->settings->disable_all ) ) {
+		if ( isset( $this->settings->disable_all ) && true === $this->settings->disable_all ) {
 			return false;
 		}
 
@@ -411,7 +411,7 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 	 */
 	public function output_upgrade_message_for_specific_plugins(): void {
 		// don't show if we are already disabling all updates
-		if ( isset( $this->settings->disable_all ) ) {
+		if ( isset( $this->settings->disable_all ) && true === $this->settings->disable_all ) {
 			return;
 		}
 
@@ -483,7 +483,7 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 	public function output_auto_updates_disabled_admin_notice(): void {
 		// add notice to the top of the screen
 		global $pagenow;
-		if ( 'plugins.php' === $pagenow && isset( $this->settings->disable_all ) ) {
+		if ( 'plugins.php' === $pagenow && isset( $this->settings->disable_all ) && true === $this->settings->disable_all ) {
 			add_action(
 				'admin_notices',
 				function () {

--- a/src/Modules/Autoupdates/PluginFilterAdminUI.php
+++ b/src/Modules/Autoupdates/PluginFilterAdminUI.php
@@ -11,6 +11,22 @@ defined( 'ABSPATH' ) || exit;
  * @version 1.0.0
  */
 class PluginFilterAdminUI {
+	/**
+	 * Centralized autoupdate settings payload.
+	 *
+	 * @var \stdClass
+	 */
+	private \stdClass $settings;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param \stdClass|null $settings Centralized settings payload.
+	 */
+	public function __construct( ?\stdClass $settings = null ) {
+		$this->settings = $settings instanceof \stdClass ? $settings : new \stdClass();
+	}
+
 
 	/**
 	 * Customize automatic update setting HTML for plugins page in wp-admin.
@@ -28,19 +44,21 @@ class PluginFilterAdminUI {
 			return $html . $toggle_link_html;
 		}
 
-		// Check if updates are explicitly blocked for this plugin.
-		if ( function_exists( 'disable_autoupdate_specific_plugins' ) ) {
-			$plugin_slug = dirname( $plugin_file );
-			if ( is_array( $plugin_data ) && isset( $plugin_data['TextDomain'] ) && is_string( $plugin_data['TextDomain'] ) && '' !== $plugin_data['TextDomain'] ) {
-				$plugin_slug = sanitize_key( $plugin_data['TextDomain'] );
-			}
+		$plugin_slug = dirname( $plugin_file );
+		if ( is_array( $plugin_data ) && isset( $plugin_data['TextDomain'] ) && is_string( $plugin_data['TextDomain'] ) && '' !== $plugin_data['TextDomain'] ) {
+			$plugin_slug = sanitize_key( $plugin_data['TextDomain'] );
+		}
 
-			$plugin_obj       = new \stdClass();
-			$plugin_obj->slug = $plugin_slug;
+		$plugin_obj         = new \stdClass();
+		$plugin_obj->slug   = $plugin_slug;
+		$plugin_obj->plugin = $plugin_file;
 
-			if ( ! PluginFilterRules::is_plugin_allowed_to_autoupdate( $plugin_obj ) ) {
-				return esc_html__( 'Autoupdates have been explicitly deactivated for this plugin.', 'a8csp-atlantis' ) . $toggle_link_html;
-			}
+		if ( PluginFilterRules::is_plugin_disabled_by_centralized_settings( $plugin_obj, $this->settings ) ) {
+			return esc_html__( 'Autoupdates have been explicitly deactivated for this plugin via global OpsOasis settings.', 'a8csp-atlantis' );
+		}
+
+		if ( PluginFilterRules::is_plugin_blocked_from_autoupdates( $plugin_obj, $this->settings ) ) {
+			return esc_html__( 'Autoupdates have been explicitly deactivated for this plugin.', 'a8csp-atlantis' ) . $toggle_link_html;
 		}
 
 		$managed_message = sprintf(

--- a/src/Modules/Autoupdates/PluginFilterRules.php
+++ b/src/Modules/Autoupdates/PluginFilterRules.php
@@ -67,4 +67,96 @@ class PluginFilterRules {
 		// @phpstan-ignore-next-line Optional external callback may be unavailable in some installs.
 		return (bool) call_user_func( '\disable_autoupdate_specific_plugins', true, $plugin_obj );
 	}
+
+	/**
+	 * Determine whether plugin autoupdates are blocked by centralized settings.
+	 *
+	 * @param \stdClass $plugin_obj Plugin-like object containing plugin and/or slug.
+	 * @param \stdClass $settings   Centralized settings.
+	 *
+	 * @return bool
+	 */
+	public static function is_plugin_disabled_by_centralized_settings( \stdClass $plugin_obj, \stdClass $settings ): bool {
+		$disabled_plugins = self::get_centrally_disabled_plugins( $settings );
+		if ( empty( $disabled_plugins ) ) {
+			return false;
+		}
+
+		$plugin_file = '';
+		if ( isset( $plugin_obj->plugin ) && is_string( $plugin_obj->plugin ) ) {
+			$plugin_file = plugin_basename( $plugin_obj->plugin );
+		}
+
+		$plugin_slug = '';
+		if ( isset( $plugin_obj->slug ) && is_string( $plugin_obj->slug ) ) {
+			$plugin_slug = sanitize_key( $plugin_obj->slug );
+		}
+
+		if ( '' === $plugin_slug && '' !== $plugin_file ) {
+			$plugin_slug = sanitize_key( dirname( $plugin_file ) );
+		}
+
+		foreach ( $disabled_plugins as $disabled_plugin_file ) {
+			$disabled_plugin_slug = sanitize_key( dirname( $disabled_plugin_file ) );
+			if ( false === strpos( $disabled_plugin_file, '/' ) ) {
+				$disabled_plugin_slug = sanitize_key( $disabled_plugin_file );
+			}
+
+			if ( '' !== $plugin_file && $plugin_file === $disabled_plugin_file ) {
+				return true;
+			}
+
+			if ( '' !== $plugin_slug && $plugin_slug === $disabled_plugin_slug ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determine whether plugin autoupdates are blocked by either external callback or centralized settings.
+	 *
+	 * @param \stdClass $plugin_obj Plugin-like object containing plugin and/or slug.
+	 * @param \stdClass $settings   Centralized settings.
+	 *
+	 * @return bool
+	 */
+	public static function is_plugin_blocked_from_autoupdates( \stdClass $plugin_obj, \stdClass $settings ): bool {
+		if ( ! self::is_plugin_allowed_to_autoupdate( $plugin_obj ) ) {
+			return true;
+		}
+
+		return self::is_plugin_disabled_by_centralized_settings( $plugin_obj, $settings );
+	}
+
+	/**
+	 * Get normalized centralized plugin files disabled from autoupdates.
+	 *
+	 * @param \stdClass $settings Centralized settings.
+	 *
+	 * @return array<int, string>
+	 */
+	private static function get_centrally_disabled_plugins( \stdClass $settings ): array {
+		if ( ! isset( $settings->disabled_plugins ) || ! is_array( $settings->disabled_plugins ) ) {
+			return array();
+		}
+
+		$normalized_plugins = array();
+
+		foreach ( $settings->disabled_plugins as $disabled_plugin ) {
+			if ( ! is_string( $disabled_plugin ) ) {
+				continue;
+			}
+
+			$disabled_plugin = plugin_basename( sanitize_text_field( $disabled_plugin ) );
+			if ( '' === $disabled_plugin || '.' === $disabled_plugin ) {
+				continue;
+			}
+
+			$normalized_plugins[] = $disabled_plugin;
+		}
+
+		return array_values( array_unique( $normalized_plugins ) );
+	}
 }

--- a/tests/Integration/AutoupdatesTestCest.php
+++ b/tests/Integration/AutoupdatesTestCest.php
@@ -87,6 +87,61 @@ class AutoupdatesTestCest {
 	}
 
 	/**
+	 * Plugin-specific centralized settings should disable matching plugin autoupdates only.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function centralized_plugin_blocks_disable_only_selected_plugins( IntegrationTester $i ): void {
+		$module = new AutoUpdatePluginsFilter();
+		$this->set_module_settings(
+			$module,
+			(object) array(
+				'canary_sites'      => array(),
+				'disabled_plugins'  => array(
+					'akismet/akismet.php',
+				),
+			)
+		);
+
+		$blocked_plugin_item = (object) array(
+			'plugin' => 'akismet/akismet.php',
+			'slug'   => 'akismet',
+		);
+		$allowed_plugin_item = (object) array(
+			'plugin' => 'hello-dolly/hello.php',
+			'slug'   => 'hello-dolly',
+		);
+
+		Assert::assertFalse( $module->filter_maybe_disable_all_autoupdates( true, $blocked_plugin_item ) );
+		Assert::assertTrue( $module->filter_maybe_disable_all_autoupdates( true, $allowed_plugin_item ) );
+	}
+
+	/**
+	 * Centrally blocked plugins should not display PAF toggle actions.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function centralized_plugin_blocks_hide_plugin_column_toggle_action( IntegrationTester $i ): void {
+		$this->set_current_user_as_admin();
+
+		$settings = (object) array(
+			'disabled_plugins' => array(
+				'akismet/akismet.php',
+			),
+		);
+
+		$admin_ui = new PluginFilterAdminUI( $settings );
+		$html     = $admin_ui->filter_custom_setting_html( 'Current setting', 'akismet/akismet.php', array() );
+
+		Assert::assertStringContainsString( 'Autoupdates have been explicitly deactivated for this plugin via global OpsOasis settings.', $html );
+		Assert::assertStringNotContainsString( 'Disable PAF updates', $html );
+	}
+
+	/**
 	 * Ensure schedule filters can be controlled through hooks.
 	 *
 	 * @param IntegrationTester $i Tester instance.


### PR DESCRIPTION
### What changed

- Added centralized `disabled_plugins` handling in Atlantis autoupdate rules.
  - New rule helpers in `PluginFilterRules` to detect centrally disabled plugins.
  - Supports plugin basenames and slug matching.
- Updated runtime autoupdate filtering in `AutoUpdatePluginsFilter`:
  - `filter_maybe_disable_all_autoupdates()` now checks plugin items against centralized `disabled_plugins`.
  - Keeps existing `disable_all` behavior intact.
  - Prevents false positives for non-plugin update items.
- Updated plugin column UI in `PluginFilterAdminUI`:
  - Shows: `Autoupdates have been explicitly deactivated for this plugin via global OpsOasis settings.`
  - Hides the `Disable PAF updates` action when plugin is globally disabled by OpsOasis.
- Updated upgrade notice behavior to align with centralized blocking logic.
- Added integration coverage in `AutoupdatesTestCest` for:
  - centrally blocked plugins being denied updates
  - plugin-column message/action behavior
- Docs/version updates:
  - `README.md` updated with centralized settings details (`disable_all`, `canary_sites`, `disabled_plugins`)
  - `a8csp-atlantis.php` version bumped to `1.0.5`
  - `README.md` stable tag bumped to `1.0.5`

## Test plan

- [x] In OpsOasis settings endpoint payload, set `disabled_plugins` to include a plugin (e.g. `akismet/akismet.php`).
- [x] On a connected Atlantis site, confirm that plugin is not auto-updated.
- [x] On `wp-admin/plugins.php`, confirm plugin row shows:
      `Autoupdates have been explicitly deactivated for this plugin via global OpsOasis settings.`
- [x] Confirm `Disable PAF updates` link is not shown for globally blocked plugin rows.
- [x] Confirm plugins not in `disabled_plugins` still follow normal Atlantis rules.
- [x] Confirm `disable_all` still disables all plugin/theme/core updates as before.
- [x] Run integration tests and verify the new autoupdates tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized autoupdate settings to globally disable all plugin autoupdates or selectively block specific plugins; admin UI now reflects centralized state and shows a global deactivation message when applicable.

* **Documentation**
  * Added "Centralized autoupdate settings" section documenting the settings endpoint and payload fields (disable_all, canary_sites, disabled_plugins).

* **Tests**
  * Added integration tests covering centralized blocking behavior and admin UI visibility.

* **Version**
  * Bumped release to 1.0.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->