### PR TITLE
Fix Atlantis settings visibility for mixed-case Automattic emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - **Requires at least:** 6.5
 - **Tested up to:** 6.8.1
 - **Requires PHP:** 8.3
-- **Stable tag:** 1.0.5
+- **Stable tag:** 1.0.6
 - **License:** GPLv3 or later
 - **License URI:** [http://www.gnu.org/licenses/gpl-3.0.html](http://www.gnu.org/licenses/gpl-3.0.html)
 

--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -15,7 +15,7 @@
  * Plugin URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Update URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Description:             Centralized site management for Team51.
- * Version:                 1.0.5
+ * Version:                 1.0.6
  * Requires at least:       6.8
  * Tested up to:            6.8.1
  * Requires PHP:            8.3

--- a/includes/miscellaneous.php
+++ b/includes/miscellaneous.php
@@ -20,8 +20,13 @@ function a8csp_atlantis_is_automattician(): bool {
 		return false;
 	}
 
-	$allowed_domains = array( '@a8c.com', '@automattic.com', '@wordpress.com' );
-	$email_domain    = strrchr( $user->user_email, '@' );
+	$allowed_domains = array( 'a8c.com', 'automattic.com', 'wordpress.com' );
+	$email           = strtolower( trim( $user->user_email ) );
+	$email_domain    = strrchr( $email, '@' );
+	if ( false === $email_domain ) {
+		return false;
+	}
+	$email_domain = ltrim( $email_domain, '@' );
 
 	return in_array( $email_domain, $allowed_domains, true );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a8csp-atlantis",
-  "version": "1.0.3",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a8csp-atlantis",
-      "version": "1.0.3",
+      "version": "1.0.6",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "select2": "^4.1.0-rc.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a8csp-atlantis",
-  "version": "1.0.3",
+  "version": "1.0.6",
   "description": "A scaffold for A8C Special Projects plugins",
   "author": {
     "name": "A8C Special Projects Team",

--- a/tests/Integration/CoreTestCest.php
+++ b/tests/Integration/CoreTestCest.php
@@ -27,6 +27,11 @@ class CoreTestCest {
 		wp_set_current_user( $allowed_user_id );
 		Assert::assertTrue( a8csp_atlantis_is_automattician() );
 
+		$mixed_case_allowed_user_id = $this->ensure_admin_user( 'wpcom-admin', 'admin@WordPress.com' );
+		Assert::assertGreaterThan( 0, $mixed_case_allowed_user_id );
+		wp_set_current_user( $mixed_case_allowed_user_id );
+		Assert::assertTrue( a8csp_atlantis_is_automattician() );
+
 		$blocked_user_id = $this->ensure_admin_user( 'site-admin', 'admin@example.com' );
 		Assert::assertGreaterThan( 0, $blocked_user_id );
 		wp_set_current_user( $blocked_user_id );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix `a8csp_atlantis_is_automattician()` to normalize user email/domain before allowlist comparison, preventing false negatives like `concierge@WordPress.com`.
* Keep strict domain matching while making it case-insensitive by lowercasing and safely parsing the domain.
* Add integration test coverage to verify mixed-case allowed domains pass (`admin@WordPress.com`) and non-allowed domains still fail.
* Bump plugin/release metadata to `1.0.6` in:
  * `a8csp-atlantis.php` (plugin header version)
  * `README.md` (Stable tag)
  * `package.json` and `package-lock.json` (package version fields)

#### Testing instructions

* Run integration tests:
  * `npm run tests:run:integration`
  * Confirm all tests pass (including `CoreTestCest::automattician_detection_uses_allowed_domains`).
* Manual verification (happy path):
  * Use an admin user with email `concierge@WordPress.com`.
  * Open wp-admin and verify the `Atlantis` menu/settings are visible.
* Regression verification:
  * Use an admin user with `@automattic.com` (all lowercase) and verify Atlantis is visible.
  * Use an admin user with a non-allowlisted domain (e.g. `@example.com`) and verify Atlantis is not shown.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email domain validation for more robust and accurate authentication checks.

* **Chores**
  * Version bumped to 1.0.6 across all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->