### PR TITLE
Update Bilmur integration to parity with team51-tracking

### DIFF
--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -3,7 +3,7 @@
  * The A8CSP Atlantis bootstrap file.
  *
  * @since       1.0.0
- * @version     1.0.8
+ * @version     1.0.9
  * @package     A8C\SpecialProjects\Plugins
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
@@ -15,7 +15,7 @@
  * Plugin URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Update URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Description:             Centralized site management for Team51.
- * Version:                 1.0.8
+ * Version:                 1.0.9
  * Requires at least:       6.8
  * Tested up to:            6.8.1
  * Requires PHP:            8.3

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -4,5 +4,5 @@ define( 'A8CSP_ATLANTIS_BASENAME', 'a8csp-atlantis/a8csp-atlantis.php' );
 define( 'A8CSP_ATLANTIS_DIR_PATH', __DIR__ . '/' );
 define( 'A8CSP_ATLANTIS_DIR_URL', '/wp-content/plugins/a8csp-atlantis' );
 define( 'A8CSP_ATLANTIS_ENCRYPTION_KEY', 'abcdefghijklmnopqrstuvwxyz0123456789' );
-define( 'WPCOMSP_BILMUR_PROVIDER', 'test-provider' );
-define( 'WPCOMSP_BILMUR_SERVICE', 'test-service' );
+define( 'WPCOMSP_BILMUR_PROVIDER', 'wpcloud' );
+define( 'WPCOMSP_BILMUR_SERVICE', 'pressable.com' );

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -4,3 +4,5 @@ define( 'A8CSP_ATLANTIS_BASENAME', 'a8csp-atlantis/a8csp-atlantis.php' );
 define( 'A8CSP_ATLANTIS_DIR_PATH', __DIR__ . '/' );
 define( 'A8CSP_ATLANTIS_DIR_URL', '/wp-content/plugins/a8csp-atlantis' );
 define( 'A8CSP_ATLANTIS_ENCRYPTION_KEY', 'abcdefghijklmnopqrstuvwxyz0123456789' );
+define( 'WPCOMSP_BILMUR_PROVIDER', 'test-provider' );
+define( 'WPCOMSP_BILMUR_SERVICE', 'test-service' );

--- a/src/Modules/Tracking/Integrations/Bilmur.php
+++ b/src/Modules/Tracking/Integrations/Bilmur.php
@@ -65,23 +65,18 @@ class Bilmur extends AbstractIntegration {
 		// WP Rocket compatibility: prevent "Delay JavaScript Execution" from
 		// blocking the bilmur beacon. The `nowprocket` attribute tells WP Rocket
 		// to skip delaying this script.
-		add_action(
-			'plugins_loaded',
-			static function () {
-				$active_plugins = get_option( 'active_plugins' );
-				if ( is_array( $active_plugins ) && in_array( 'wp-rocket/wp-rocket.php', $active_plugins, true ) ) {
-					add_filter(
-						'wp_script_attributes',
-						static function ( array $attributes ): array {
-							if ( isset( $attributes['id'] ) && 'bilmur-js' === $attributes['id'] ) {
-								$attributes['nowprocket'] = true;
-							}
-							return $attributes;
-						}
-					);
+		$active_plugins = get_option( 'active_plugins' );
+		if ( is_array( $active_plugins ) && in_array( 'wp-rocket/wp-rocket.php', $active_plugins, true ) ) {
+			add_filter(
+				'wp_script_attributes',
+				static function ( array $attributes ): array {
+					if ( isset( $attributes['id'] ) && 'bilmur-js' === $attributes['id'] ) {
+						$attributes['nowprocket'] = true;
+					}
+					return $attributes;
 				}
-			}
-		);
+			);
+		}
 
 		// Output bilmur config as a <meta> tag for the script to pick up.
 		add_action(

--- a/src/Modules/Tracking/Integrations/Bilmur.php
+++ b/src/Modules/Tracking/Integrations/Bilmur.php
@@ -24,7 +24,7 @@ class Bilmur extends AbstractIntegration {
 			return false;
 		}
 
-		if ( ! defined( 'WPCOMSP_BILMUR_PROVIDER' ) || ! defined( 'WPCOMSP_BILMUR_SERVICE' ) ) {
+		if ( ! defined( 'WPCOMSP_BILMUR_PROVIDER' ) || ! WPCOMSP_BILMUR_PROVIDER || ! defined( 'WPCOMSP_BILMUR_SERVICE' ) || ! WPCOMSP_BILMUR_SERVICE ) {
 			return false;
 		}
 

--- a/src/Modules/Tracking/Integrations/Bilmur.php
+++ b/src/Modules/Tracking/Integrations/Bilmur.php
@@ -7,55 +7,156 @@ use A8C\SpecialProjects\Atlantis\Modules\Tracking\AbstractIntegration;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * WooCommerce Integration class.
+ * Bilmur RUM Integration class.
  *
  * @since   1.0.0
- * @version 1.0.0
+ * @version 1.1.0
  */
 class Bilmur extends AbstractIntegration {
 	/**
 	 * {@inheritDoc}
 	 *
 	 * @since   1.0.0
-	 * @version 1.0.0
+	 * @version 1.1.0
 	 */
 	public function is_active(): bool {
-		return defined( 'WPCOMSP_BILMUR_TRACKING' ) && WPCOMSP_BILMUR_TRACKING;
+		if ( ! defined( 'WPCOMSP_BILMUR_TRACKING' ) || ! WPCOMSP_BILMUR_TRACKING ) {
+			return false;
+		}
+
+		if ( ! defined( 'WPCOMSP_BILMUR_PROVIDER' ) || ! defined( 'WPCOMSP_BILMUR_SERVICE' ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 *
 	 * @since   1.0.0
-	 * @version 1.0.0
+	 * @version 1.1.0
 	 */
 	protected function initialize(): void {
 		add_action(
 			'wp_enqueue_scripts',
 			static function () {
-				wp_enqueue_script( 'bilmur', 'https://s0.wp.com/wp-content/js/bilmur.min.js?m=202215', array(), '1.0.0', true );
+				// Request a new version of bilmur every week.
+				// This keeps bilmur up-to-date independently of CDN caching times.
+				$weekly_cachebust = 'm=' . gmdate( 'YW' );
+
+				// Allow for manually forcing a new version of bilmur with a plugin update.
+				// Just increment this number if that's the case.
+				$manual_version = '1';
+
+				wp_enqueue_script(
+					'bilmur',
+					'https://s0.wp.com/wp-content/js/bilmur.min.js?' . $weekly_cachebust,
+					array(),
+					$manual_version,
+					array(
+						'strategy'  => 'defer',
+						'in_footer' => true,
+					)
+				);
 			}
 		);
 
-		add_filter(
-			'script_loader_tag',
-			static function ( $tag, $handle ) {
-				if ( 'bilmur' === $handle ) {
-					if ( defined( 'WPCOMSP_BILMUR_PROVIDER' ) ) {
-						$tag = str_replace( ' src', ' data-provider="' . WPCOMSP_BILMUR_PROVIDER . '" src', $tag );
-					}
-					if ( defined( 'WPCOMSP_BILMUR_SERVICE' ) ) {
-						$tag = str_replace( ' src', ' data-service="' . WPCOMSP_BILMUR_SERVICE . '" src', $tag );
-					}
-					if ( defined( 'WPCOMSP_BILMUR_CUSTOM_PROPERTIES' ) ) {
-						$tag = str_replace( ' src', ' data-customproperties="' . wp_json_encode( WPCOMSP_BILMUR_CUSTOM_PROPERTIES ) . '" src', $tag );
-					}
+		// WP Rocket compatibility: prevent "Delay JavaScript Execution" from
+		// blocking the bilmur beacon. The `nowprocket` attribute tells WP Rocket
+		// to skip delaying this script.
+		add_action(
+			'plugins_loaded',
+			static function () {
+				$active_plugins = get_option( 'active_plugins' );
+				if ( is_array( $active_plugins ) && in_array( 'wp-rocket/wp-rocket.php', $active_plugins, true ) ) {
+					add_filter(
+						'wp_script_attributes',
+						static function ( array $attributes ): array {
+							if ( isset( $attributes['id'] ) && 'bilmur-js' === $attributes['id'] ) {
+								$attributes['nowprocket'] = true;
+							}
+							return $attributes;
+						}
+					);
 				}
-
-				return $tag;
-			},
-			10,
-			2
+			}
 		);
+
+		// Output bilmur config as a <meta> tag for the script to pick up.
+		add_action(
+			'wp_footer',
+			static function () {
+				$custom_properties = defined( 'WPCOMSP_BILMUR_CUSTOM_PROPERTIES' ) ? WPCOMSP_BILMUR_CUSTOM_PROPERTIES : array();
+
+				$custom_properties['woo_active'] = class_exists( 'WooCommerce' ) ? '1' : '0';
+
+				?>
+				<meta
+					id="bilmur"
+					property="bilmur:data"
+					content=""
+					data-provider="<?php echo esc_attr( WPCOMSP_BILMUR_PROVIDER ); ?>"
+					data-service="<?php echo esc_attr( WPCOMSP_BILMUR_SERVICE ); ?>"
+					data-custom-props="<?php echo esc_attr( (string) wp_json_encode( $custom_properties ) ); ?>"
+					data-site-tz="<?php echo esc_attr( self::get_timezone_string() ); ?>"
+				>
+				<?php
+			}
+		);
+	}
+
+	/**
+	 * Returns a standardized timezone string.
+	 *
+	 * `wp_timezone_string()` sometimes returns offsets (e.g. "-07:00"), which are
+	 * a non-standard representation that only works in PHP. This method returns a
+	 * standardized timezone string instead, of the form "Etc/GMT+7" for integer
+	 * hour offsets, or a matching "<Area>/<City>" form for fractional hour offsets.
+	 *
+	 * @since   1.1.0
+	 * @version 1.1.0
+	 *
+	 * @return string
+	 */
+	private static function get_timezone_string(): string {
+		$wp_tz = wp_timezone_string();
+
+		if ( '' === $wp_tz ) {
+			return 'UTC';
+		}
+
+		// Handle "+/-HH:MM" offset format.
+		if ( 1 === preg_match( '/^([+-])?(\d{1,2}):(\d{2})$/', $wp_tz, $matches ) ) {
+			$sign    = '-' === $matches[1] ? -1 : 1;
+			$hours   = intval( $matches[2], 10 );
+			$minutes = intval( $matches[3], 10 );
+
+			// For fractional hour offsets, find a matching "<Area>/<City>" timezone.
+			if ( $minutes > 0 ) {
+				$offset  = $sign * ( $hours * 3600 + $minutes * 60 );
+				$city_tz = timezone_name_from_abbr( '', $offset, 0 );
+
+				if ( false !== $city_tz && '' !== $city_tz ) {
+					return $city_tz;
+				}
+			}
+
+			// For integer hour offsets, use "Etc/GMT(+|-)N".
+			// The sign is flipped to match how the Etc area is specced.
+			// This codepath is also the fallback when no city matches a fractional offset.
+			return 'Etc/GMT' . ( -1 === $sign ? '+' : '-' ) . $hours;
+		}
+
+		// Handle legacy "UTC±N" offsets.
+		if ( 1 === preg_match( '/^UTC([+-])(\d{1,2})$/i', $wp_tz, $matches ) ) {
+			$sign  = '-' === $matches[1] ? -1 : 1;
+			$hours = intval( $matches[2], 10 );
+
+			return 'Etc/GMT' . ( -1 === $sign ? '+' : '-' ) . $hours;
+		}
+
+		// For named timezones, return as-is.
+		return $wp_tz;
 	}
 }


### PR DESCRIPTION
Related to a8cteam51/team51-tracking

## Proposed changes

* Replace the old `script_loader_tag` string replacement approach with a `<meta>` tag in `wp_footer` for bilmur config (provider, service, custom properties, timezone)
* Switch to weekly cache-busting URL (`gmdate('YW')`) instead of hardcoded `?m=202215`
* Use `defer` script strategy with `in_footer` for non-blocking page load
* Add WP Rocket compatibility via `nowprocket` attribute on `wp_script_attributes` filter
* Add automatic `woo_active` custom property for WooCommerce detection
* Require `WPCOMSP_BILMUR_PROVIDER` and `WPCOMSP_BILMUR_SERVICE` constants in `is_active()` (fail fast when config is incomplete)
* Add `get_timezone_string()` method to normalize WordPress timezone offsets for bilmur
* Add bilmur constants to `phpstan-bootstrap.php` for static analysis

## Why are these changes being made?

The Atlantis Bilmur integration was ported from an early version of `team51-tracking` (circa mid-2023) and missed all subsequent improvements. The upstream plugin has since added:

- **Performance**: deferred script loading and dynamic cache-busting to keep bilmur up to date
- **Stability**: WP Rocket compatibility (without it, "Delay JS Execution" silently blocks bilmur beacons), proper timezone normalization, and a fail-fast check for required constants
- **Reliability**: the `<meta>` tag approach is independent of the script tag format, unlike the old `str_replace(' src', ...)` method which could break if any plugin modifies the script tag

This brings Atlantis to full parity with `team51-tracking` at commit `0396367`.

## Testing instructions

* Confirm bilmur does NOT load without all three constants (`WPCOMSP_BILMUR_TRACKING`, `WPCOMSP_BILMUR_PROVIDER`, `WPCOMSP_BILMUR_SERVICE`)
* Add all three constants to `wp-config.php`, verify the `<meta id="bilmur">` tag appears in the page footer with correct `data-provider`, `data-service`, `data-custom-props`, and `data-site-tz` attributes
* Verify the bilmur script tag uses a weekly cache-bust URL (`?m=YYYYWW`) and has the `defer` attribute
* On a site with WP Rocket active, verify the bilmur script tag has the `nowprocket` attribute
* On a site with WooCommerce active, verify `data-custom-props` includes `"woo_active":"1"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WP Rocket compatibility for improved script optimization.
  * Emits runtime configuration metadata (provider, service, custom properties) for tracking via a meta tag.
  * Timezone normalization to improve geographic tracking accuracy.
  * Default global configuration values added for provider/service.

* **Bug Fixes**
  * Strengthened activation checks to prevent tracking when configuration is incomplete.

* **Updates**
  * Integration version bumped to 1.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->