### PR TITLE
Fix failed nonce checks for legacy PT save

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - **Requires at least:** 6.5
 - **Tested up to:** 6.8.1
 - **Requires PHP:** 8.3
-- **Stable tag:** 1.0.6
+- **Stable tag:** 1.0.7
 - **License:** GPLv3 or later
 - **License URI:** [http://www.gnu.org/licenses/gpl-3.0.html](http://www.gnu.org/licenses/gpl-3.0.html)
 

--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -3,7 +3,7 @@
  * The A8CSP Atlantis bootstrap file.
  *
  * @since       1.0.0
- * @version     1.0.5
+ * @version     1.0.7
  * @package     A8C\SpecialProjects\Plugins
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
@@ -15,7 +15,7 @@
  * Plugin URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Update URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Description:             Centralized site management for Team51.
- * Version:                 1.0.6
+ * Version:                 1.0.7
  * Requires at least:       6.8
  * Tested up to:            6.8.1
  * Requires PHP:            8.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a8csp-atlantis",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A scaffold for A8C Special Projects plugins",
   "author": {
     "name": "A8C Special Projects Team",

--- a/src/Modules/Messages/ListTable.php
+++ b/src/Modules/Messages/ListTable.php
@@ -172,6 +172,11 @@ class ListTable {
 	 * @return  void
 	 */
 	public function handle_bulk_actions(): void {
+		// // Only handle bulk actions on our list screen. WordPress post/CPT saves redirect
+		$page = isset( $_REQUEST['page'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['page'] ) ) : '';
+		if ( 'a8csp-atlantis-messages' !== $page ) {
+			return;
+		}
 		if ( ! isset( $_REQUEST['action'] ) || ! isset( $_REQUEST['message'] ) ) {
 			return;
 		}


### PR DESCRIPTION
## Changes proposed in this Pull Request
- **Issue:** On **Save** in the **classic (legacy) post editor**, admins could hit **“The link you followed has expired.”** That redirect includes `action=edit` and `message=<n>` (success notice). Atlantis’s `handle_bulk_actions()` ran on every `admin_init` and treated any request with both `action` and `message` as an Atlantis Messages bulk action, then called `check_admin_referer( 'bulk-messages' )`, which failed and triggered the nonce expiry screen.
- **Fix:** Only run bulk handling when `page` is `a8csp-atlantis-messages` (the Atlantis Messages list screen), so normal post/CPT save redirects are ignored.

## Testing instructions
1. With the **classic editor**, edit and **Update** a post or CPT; confirm you return to the editor with a success state and **no** “link expired” / nonce error.
2. In **wp-admin → Atlantis → Messages**, use **Bulk actions** (e.g. activate/deactivate/delete) on selected rows; confirm it still works and does not error.
3. (Optional) Repeat a post save in the **block editor** to confirm no regression (reported unaffected, but quick sanity check).

## Mentions
@Ninodevo only tagging you as I seen you worked on this recently, please let me know if there's someone else to tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version to 1.0.7

* **Bug Fixes**
  * Improved bulk action handling to prevent conflicts on non-message admin screens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->