### PR TITLE
Add/update transient

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - **Requires at least:** 6.5
 - **Tested up to:** 6.8.1
 - **Requires PHP:** 8.3
-- **Stable tag:** 1.0.7
+- **Stable tag:** 1.0.8
 - **License:** GPLv3 or later
 - **License URI:** [http://www.gnu.org/licenses/gpl-3.0.html](http://www.gnu.org/licenses/gpl-3.0.html)
 

--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -15,7 +15,7 @@
  * Plugin URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Update URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Description:             Centralized site management for Team51.
- * Version:                 1.0.7
+ * Version:                 1.0.8
  * Requires at least:       6.8
  * Tested up to:            6.8.1
  * Requires PHP:            8.3

--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -33,6 +33,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'A8CSP_ATLANTIS_BASENAME', plugin_basename( __FILE__ ) );
 define( 'A8CSP_ATLANTIS_DIR_PATH', plugin_dir_path( __FILE__ ) );
 define( 'A8CSP_ATLANTIS_DIR_URL', plugin_dir_url( __FILE__ ) );
+define( 'A8CSP_ATLANTIS_GITHUB_RELEASE_TRANSIENT_KEY', 'a8csp_atlantis_github_latest_release' );
 
 // Load the rest of the bootstrap functions.
 require_once A8CSP_ATLANTIS_DIR_PATH . '/functions-bootstrap.php';
@@ -58,12 +59,28 @@ add_action(
 			return $update;
 		}
 
-		$latest_release_info = wp_remote_get( 'https://api.github.com/repos/a8cteam51/a8csp-atlantis/releases/latest' );
-		if ( is_wp_error( $latest_release_info ) || 200 !== wp_remote_retrieve_response_code( $latest_release_info ) ) {
-			return $update;
+		$latest_release_info = get_transient( A8CSP_ATLANTIS_GITHUB_RELEASE_TRANSIENT_KEY );
+		if ( false === $latest_release_info ) {
+			$latest_release_info = wp_remote_get( 'https://api.github.com/repos/a8cteam51/a8csp-atlantis/releases/latest' );
+			if ( is_wp_error( $latest_release_info ) || 200 !== wp_remote_retrieve_response_code( $latest_release_info ) ) {
+				return $update;
+			}
+
+			$latest_release_info = json_decode( wp_remote_retrieve_body( $latest_release_info ), true );
+			if (
+				! is_array( $latest_release_info ) ||
+				! isset( $latest_release_info['tag_name'], $latest_release_info['html_url'], $latest_release_info['assets'][0]['browser_download_url'] )
+			) {
+				return $update;
+			}
+
+			set_transient(
+				A8CSP_ATLANTIS_GITHUB_RELEASE_TRANSIENT_KEY,
+				$latest_release_info,
+				HOUR_IN_SECONDS
+			);
 		}
 
-		$latest_release_info    = json_decode( wp_remote_retrieve_body( $latest_release_info ), true );
 		$latest_release_version = ltrim( $latest_release_info['tag_name'], 'v' );
 		if ( version_compare( $plugin_data['Version'], $latest_release_version, '<' ) ) {
 			$update = array(

--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -3,7 +3,7 @@
  * The A8CSP Atlantis bootstrap file.
  *
  * @since       1.0.0
- * @version     1.0.7
+ * @version     1.0.8
  * @package     A8C\SpecialProjects\Plugins
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
@@ -60,9 +60,15 @@ add_action(
 		}
 
 		$latest_release_info = get_transient( A8CSP_ATLANTIS_GITHUB_RELEASE_TRANSIENT_KEY );
-		if ( false === $latest_release_info ) {
+		if (
+			is_array( $latest_release_info ) &&
+			isset( $latest_release_info['tag_name'], $latest_release_info['html_url'], $latest_release_info['assets'][0]['browser_download_url'] )
+		) {
+			$latest_release_version = ltrim( $latest_release_info['tag_name'], 'v' );
+		} elseif ( false === $latest_release_info ) {
 			$latest_release_info = wp_remote_get( 'https://api.github.com/repos/a8cteam51/a8csp-atlantis/releases/latest' );
 			if ( is_wp_error( $latest_release_info ) || 200 !== wp_remote_retrieve_response_code( $latest_release_info ) ) {
+				set_transient( A8CSP_ATLANTIS_GITHUB_RELEASE_TRANSIENT_KEY, array(), 5 * MINUTE_IN_SECONDS );
 				return $update;
 			}
 
@@ -71,6 +77,7 @@ add_action(
 				! is_array( $latest_release_info ) ||
 				! isset( $latest_release_info['tag_name'], $latest_release_info['html_url'], $latest_release_info['assets'][0]['browser_download_url'] )
 			) {
+				set_transient( A8CSP_ATLANTIS_GITHUB_RELEASE_TRANSIENT_KEY, array(), 5 * MINUTE_IN_SECONDS );
 				return $update;
 			}
 
@@ -79,9 +86,11 @@ add_action(
 				$latest_release_info,
 				HOUR_IN_SECONDS
 			);
+			$latest_release_version = ltrim( $latest_release_info['tag_name'], 'v' );
+		} else {
+			return $update;
 		}
 
-		$latest_release_version = ltrim( $latest_release_info['tag_name'], 'v' );
 		if ( version_compare( $plugin_data['Version'], $latest_release_version, '<' ) ) {
 			$update = array(
 				'slug'    => $plugin_data['TextDomain'],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Added a 1-hour transient cache to the GitHub update check to prevent GH limit hits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped plugin version to 1.0.8
  * Updated the plugin’s release check to cache GitHub release data for faster update checks and reduced remote requests
  * Added fallback handling to make update checks more resilient when remote data is unavailable or invalid
<!-- end of auto-generated comment: release notes by coderabbit.ai -->