### PR TITLE
Fix: Block editor XSS vulnerability in message notifications

### DIFF
--- a/src/Modules/Messages/Notifications.php
+++ b/src/Modules/Messages/Notifications.php
@@ -54,9 +54,9 @@ class Notifications {
 				wp_add_inline_script(
 					'wp-edit-post',
 					wp_sprintf(
-						'wp.data.dispatch("core/notices").createNotice("%s", %s, { isDismissible: false, __unstableHTML: true });',
+						'wp.data.dispatch("core/notices").createNotice("%s", %s, { isDismissible: false });',
 						$message->type,
-						wp_json_encode( wp_kses_post( $message->content ) )
+						wp_json_encode( wp_strip_all_tags( $message->content ) )
 					)
 				);
 			} else {


### PR DESCRIPTION
## Summary
- Replaced `wp_kses_post()` with `wp_strip_all_tags()` for block editor notice content
- Removed `__unstableHTML: true` flag from `wp.data.dispatch("core/notices").createNotice()` call

`wp_kses_post()` allows `<img>` tags with event handlers (e.g., `<img src=x onerror="alert('XSS')">`), which execute JavaScript when rendered with `__unstableHTML: true`. Messages now display as plain text in the block editor, which is the safe default.

## Test plan
- [ ] Create a message with HTML content (e.g., `<b>Bold</b> text`)
- [ ] Verify it displays as plain text in the block editor notice
- [ ] Verify it still renders with `wp_admin_notice()` on non-block-editor pages
- [ ] Verify no JavaScript execution from `<img onerror="...">` payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)