### PR TITLE
Fix: Message model encryption/decryption error handling

### DIFF
--- a/models/Message.php
+++ b/models/Message.php
@@ -77,7 +77,7 @@ class Message {
 		return match ( $key ) {
 			'id' => absint( $this->data->id ?? 0 ),
 			'title', 'type', 'status', 'created_at', 'updated_at' => $this->data->$key ?? null,
-			'content' => a8csp_atlantis_decrypt_data( $this->data->content ?? '' ),
+			'content' => $this->decrypt_content(),
 			'locations', 'exclusions' => json_decode( $this->data->$key ?? '{}', true ),
 			default => null,
 		};
@@ -104,7 +104,10 @@ class Message {
 				$this->data->$key = $value;
 				break;
 			case 'content':
-				$this->data->content = a8csp_atlantis_encrypt_data( $value );
+				$encrypted = a8csp_atlantis_encrypt_data( $value );
+				if ( ! is_wp_error( $encrypted ) ) {
+					$this->data->content = $encrypted;
+				}
 				break;
 			case 'locations':
 			case 'exclusions':
@@ -154,6 +157,19 @@ class Message {
 	// region HELPERS
 
 	/**
+	 * Safely decrypts the stored message content.
+	 *
+	 * @since   1.0.9
+	 * @version 1.0.9
+	 *
+	 * @return string The decrypted content, or an empty string on failure.
+	 */
+	protected function decrypt_content(): string {
+		$decrypted = a8csp_atlantis_decrypt_data( $this->data->content ?? '' );
+		return is_wp_error( $decrypted ) ? '' : $decrypted;
+	}
+
+	/**
 	 * Returns the default data structure for a new message.
 	 *
 	 * @since   1.0.0
@@ -162,10 +178,12 @@ class Message {
 	 * @return  \stdClass
 	 */
 	protected function get_default_data(): \stdClass {
+		$encrypted_content = a8csp_atlantis_encrypt_data( '' );
+
 		return (object) array(
 			'id'         => 0,
 			'title'      => '',
-			'content'    => a8csp_atlantis_encrypt_data( '' ),
+			'content'    => is_wp_error( $encrypted_content ) ? '' : $encrypted_content,
 			'type'       => 'info',
 			'status'     => 'active',
 			'locations'  => wp_json_encode( array() ),


### PR DESCRIPTION
## Summary
- Added `decrypt_content()` helper that safely returns empty string when decryption fails
- Added `is_wp_error()` check before storing encrypted content in `__set`
- Added fallback in `get_default_data()` when encrypting empty string fails

When the encryption key is undefined (e.g., wp-config.php not writable during deployment), `a8csp_atlantis_encrypt_data()` and `a8csp_atlantis_decrypt_data()` return `WP_Error`. Without these checks, `WP_Error` objects get stored in the database as message content, permanently corrupting the data.

## Test plan
- [ ] Create a message with valid encryption key — verify content encrypts/decrypts normally
- [ ] Temporarily remove `A8CSP_ATLANTIS_ENCRYPTION_KEY` constant — verify new messages get empty content instead of corrupted data
- [ ] Verify existing encrypted messages return empty string instead of `WP_Error` when key is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)