### PR TITLE
Fix: Isolate module initialization to prevent cascading failures

### DIFF
--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -4,5 +4,7 @@ define( 'A8CSP_ATLANTIS_BASENAME', 'a8csp-atlantis/a8csp-atlantis.php' );
 define( 'A8CSP_ATLANTIS_DIR_PATH', __DIR__ . '/' );
 define( 'A8CSP_ATLANTIS_DIR_URL', '/wp-content/plugins/a8csp-atlantis' );
 define( 'A8CSP_ATLANTIS_ENCRYPTION_KEY', 'abcdefghijklmnopqrstuvwxyz0123456789' );
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 define( 'WPCOMSP_BILMUR_PROVIDER', 'wpcloud' );
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 define( 'WPCOMSP_BILMUR_SERVICE', 'pressable.com' );

--- a/src/Modules.php
+++ b/src/Modules.php
@@ -33,8 +33,8 @@ class Modules {
 	/**
 	 * Module initialization errors.
 	 *
-	 * @since   1.0.10
-	 * @version 1.0.10
+	 * @since   1.0.9
+	 * @version 1.0.9
 	 *
 	 * @var array<string, \WP_Error>
 	 */
@@ -107,8 +107,8 @@ class Modules {
 	/**
 	 * Render admin notices for module initialization failures.
 	 *
-	 * @since   1.0.10
-	 * @version 1.0.10
+	 * @since   1.0.9
+	 * @version 1.0.9
 	 *
 	 * @return  void
 	 */

--- a/src/Modules.php
+++ b/src/Modules.php
@@ -26,9 +26,19 @@ class Modules {
 	 * @since   1.0.0
 	 * @version 1.0.0
 	 *
-	 * @var array<string, ?AbstractModule>
+	 * @var array<string, AbstractModule>
 	 */
-	public array $modules;
+	public array $modules = array();
+
+	/**
+	 * Module initialization errors.
+	 *
+	 * @since   1.0.10
+	 * @version 1.0.10
+	 *
+	 * @var array<string, \WP_Error>
+	 */
+	private array $module_errors = array();
 
 	// endregion
 
@@ -44,8 +54,8 @@ class Modules {
 	 */
 	public function initialize(): void {
 		add_action( 'a8csp/atlantis/admin_menu_registered', array( $this, 'register_admin_menu' ) );
+		add_action( 'admin_notices', array( $this, 'render_module_errors' ) );
 
-		$this->modules = array();
 		$this->try_initialize_module( 'messages', static fn() => new Messages() );
 		$this->try_initialize_module( 'colophon', static fn() => new Colophon() );
 		$this->try_initialize_module( 'tracking', static fn() => new Tracking() );
@@ -70,6 +80,16 @@ class Modules {
 			$module->maybe_initialize();
 			$this->modules[ $key ] = $module;
 		} catch ( \Throwable $throwable ) {
+			$this->module_errors[ $key ] = new \WP_Error(
+				'module_initialization_failed',
+				sprintf(
+					/* translators: 1: Module key, 2: Error message */
+					__( 'Failed to initialize Atlantis module "%1$s": %2$s', 'a8csp-atlantis' ),
+					$key,
+					$throwable->getMessage()
+				)
+			);
+
 			error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 				sprintf(
 					'[A8CSP Atlantis] Failed to initialize module "%s": %s',
@@ -83,6 +103,23 @@ class Modules {
 	// endregion
 
 	// region HOOKS
+
+	/**
+	 * Render admin notices for module initialization failures.
+	 *
+	 * @since   1.0.10
+	 * @version 1.0.10
+	 *
+	 * @return  void
+	 */
+	public function render_module_errors(): void {
+		foreach ( $this->module_errors as $error ) {
+			wp_admin_notice(
+				esc_html( $error->get_error_message() ),
+				array( 'type' => 'error' )
+			);
+		}
+	}
 
 	/**
 	 * Registers a submenu page for the Atlantis Modules settings.

--- a/src/Modules.php
+++ b/src/Modules.php
@@ -45,14 +45,38 @@ class Modules {
 	public function initialize(): void {
 		add_action( 'a8csp/atlantis/admin_menu_registered', array( $this, 'register_admin_menu' ) );
 
-		$this->modules = array(
-			'messages'    => new Messages(),
-			'colophon'    => new Colophon(),
-			'tracking'    => new Tracking(),
-			'autoupdates' => new AutoUpdatePluginsFilter(),
-		);
-		foreach ( $this->modules as $module ) {
+		$this->modules = array();
+		$this->try_initialize_module( 'messages', static fn() => new Messages() );
+		$this->try_initialize_module( 'colophon', static fn() => new Colophon() );
+		$this->try_initialize_module( 'tracking', static fn() => new Tracking() );
+		$this->try_initialize_module( 'autoupdates', static fn() => new AutoUpdatePluginsFilter() );
+	}
+
+	/**
+	 * Attempts to initialize a module, catching any errors to prevent
+	 * a single module failure from breaking the entire plugin.
+	 *
+	 * @since   1.0.9
+	 * @version 1.0.9
+	 *
+	 * @param string                     $key     The module key.
+	 * @param callable(): AbstractModule $factory A callable that creates the module instance.
+	 *
+	 * @return void
+	 */
+	private function try_initialize_module( string $key, callable $factory ): void {
+		try {
+			$module = $factory();
 			$module->maybe_initialize();
+			$this->modules[ $key ] = $module;
+		} catch ( \Throwable $throwable ) {
+			error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				sprintf(
+					'[A8CSP Atlantis] Failed to initialize module "%s": %s',
+					$key,
+					$throwable->getMessage()
+				)
+			);
 		}
 	}
 

--- a/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
+++ b/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
@@ -419,9 +419,9 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 
 		foreach ( array_keys( $all_plugins ) as $plugin_file ) {
 			// create a fake object to feed to disable_autoupdate_specific_plugins
-			$plugin_obj        = new \stdClass();
-			$slug              = dirname( $plugin_file );
-			$plugin_obj->slug  = $slug;
+			$plugin_obj         = new \stdClass();
+			$slug               = dirname( $plugin_file );
+			$plugin_obj->slug   = $slug;
 			$plugin_obj->plugin = $plugin_file;
 			$plugin_can_update  = ! PluginFilterRules::is_plugin_blocked_from_autoupdates( $plugin_obj, $this->settings );
 			if ( false === $plugin_can_update ) {


### PR DESCRIPTION
## Summary
- Wrapped each module's construction and initialization in try-catch(Throwable)
- A single module failure no longer prevents other modules from loading
- Errors are logged via error_log() for debugging

Previously, all four modules were instantiated in a single array literal. If any constructor threw (e.g., a missing dependency in Tracking), the entire plugin would fatal — taking down Messages, Autoupdates, and Colophon too.

## Test plan
- [ ] Verify all four modules load normally
- [ ] Simulate a module failure (e.g., temporarily throw in a constructor) — verify other modules still initialize
- [ ] Check error_log for the expected error message format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module initialization: failures for individual modules no longer abort startup and now show admin error notices so problematic modules are reported instead of failing silently.

* **Style**
  * Minor code formatting tweaks to improve readability of update-related messaging logic.

* **Chores**
  * Added linting suppression comments to address naming-check warnings without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->