### PR TITLE
Fix: New Year's holiday window year-boundary bug

### DIFF
--- a/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
+++ b/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
@@ -345,14 +345,17 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 	 * @return bool
 	 */
 	private function is_within_holiday_window(): bool {
+		$current_year  = gmdate( 'Y' );
+		$new_years_year = 12 === (int) gmdate( 'n' ) ? (int) $current_year + 1 : (int) $current_year;
+
 		$holidays = array(
 			'christmas' => array(
-				'start' => gmdate( 'Y' ) . '-12-23 00:00:00',
-				'end'   => gmdate( 'Y' ) . '-12-31 23:59:59',
+				'start' => $current_year . '-12-23 00:00:00',
+				'end'   => $current_year . '-12-31 23:59:59',
 			),
 			'new_years' => array(
-				'start' => gmdate( 'Y' ) . '-01-01 00:00:00',
-				'end'   => gmdate( 'Y' ) . '-01-02 23:59:59',
+				'start' => $new_years_year . '-01-01 00:00:00',
+				'end'   => $new_years_year . '-01-02 23:59:59',
 			),
 		);
 		$holidays = apply_filters( 'plugin_autoupdate_filter_holidays', $holidays ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound


### PR DESCRIPTION
## Summary
- Fixed date calculation for New Year's auto-update freeze window
- When current month is December, New Year's dates now correctly point to next year's January 1-2

On December 31st, `gmdate('Y')` returns the current year (e.g., 2026), so the New Year's freeze window was checking Jan 1-2, 2026 — 364 days in the past. Auto-updates would proceed during the holiday freeze when nobody is monitoring.

## Test plan
- [ ] Verify Christmas window still works (Dec 23-31)
- [ ] Verify New Year's window blocks updates on Jan 1-2
- [ ] Verify the `plugin_autoupdate_filter_holidays` filter still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic plugin update behavior during holiday periods, particularly around the New Year transition. The system now correctly calculates holiday windows based on the current date, ensuring more accurate update scheduling throughout the year.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->