### PR TITLE
Fix: WP requirements fallback version mismatch

### DIFF
--- a/functions-bootstrap.php
+++ b/functions-bootstrap.php
@@ -117,7 +117,7 @@ function a8csp_atlantis_validate_requirements() {
 		$plugin_metadata['RequiresPHP'] = '8.3';
 	}
 	if ( ! isset( $plugin_metadata['RequiresWP'] ) || '' === $plugin_metadata['RequiresWP'] ) {
-		$plugin_metadata['RequiresWP'] = '6.7';
+		$plugin_metadata['RequiresWP'] = '6.8';
 	}
 
 	$is_php_compatible = a8csp_atlantis_is_php_version_compatible( $plugin_metadata['RequiresPHP'] );


### PR DESCRIPTION
## Summary
- Changed fallback `RequiresWP` from `'6.7'` to `'6.8'` to match the plugin header

## Test plan
- [ ] Verify plugin still activates on WordPress 6.8+
- [ ] Verify the requirement error shows on WordPress < 6.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default minimum WordPress version requirement from version 6.7 to version 6.8 to ensure compatibility with current WordPress standards. The plugin's validation process now checks against this new baseline, with adjusted error messages provided when your WordPress installation does not meet the updated system requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->