### PR TITLE
Fix: Move activation hook after requirements validation

### DIFF
--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -37,7 +37,6 @@ define( 'A8CSP_ATLANTIS_GITHUB_RELEASE_TRANSIENT_KEY', 'a8csp_atlantis_github_la
 
 // Load the rest of the bootstrap functions.
 require_once A8CSP_ATLANTIS_DIR_PATH . '/functions-bootstrap.php';
-register_activation_hook( __FILE__, 'a8csp_atlantis_maybe_disable_autoupdates_module_on_activation' );
 
 // Load plugin translations so they are available even for the error admin notices.
 add_action(
@@ -121,5 +120,6 @@ if ( is_wp_error( A8CSP_ATLANTIS_REQUIREMENTS ) ) {
 	a8csp_atlantis_output_requirements_error( A8CSP_ATLANTIS_REQUIREMENTS );
 } else {
 	require_once A8CSP_ATLANTIS_DIR_PATH . '/functions.php';
+	register_activation_hook( __FILE__, 'a8csp_atlantis_maybe_disable_autoupdates_module_on_activation' );
 	add_action( 'plugins_loaded', array( a8csp_atlantis_get_plugin_instance(), 'maybe_initialize' ) );
 }


### PR DESCRIPTION
## Summary
- Moved `register_activation_hook()` from before requirements validation to after `functions.php` is loaded

The activation callback calls `a8csp_atlantis_generate_module_settings_key()` which is defined in `includes/settings.php`, only loaded via `functions.php` after requirements pass. On environments that don't meet requirements, activating the plugin would cause a fatal error.

## Test plan
- [ ] Verify plugin activation still works on supported environments
- [ ] Verify autoupdates module disable logic still runs on activation when legacy PAF is inactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected module initialization to ensure auto-update handling only activates after system requirement validation succeeds, preventing unintended behavior when prerequisites are not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->