### PR TITLE
Fix: Add type validation for OpsOasis auto-update settings

### DIFF
--- a/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
+++ b/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
@@ -165,6 +165,17 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 			$settings = $decoded_body;
 		}
 
+		// Normalize types to prevent issues with API responses that use strings instead of proper types.
+		if ( isset( $settings->disable_all ) ) {
+			$settings->disable_all = filter_var( $settings->disable_all, FILTER_VALIDATE_BOOLEAN );
+		}
+		if ( isset( $settings->canary_sites ) && ! is_array( $settings->canary_sites ) ) {
+			$settings->canary_sites = array();
+		}
+		if ( isset( $settings->disabled_plugins ) && ! is_array( $settings->disabled_plugins ) ) {
+			$settings->disabled_plugins = array();
+		}
+
 		return $settings;
 	}
 


### PR DESCRIPTION
## Summary
- Added type normalization for OpsOasis API response fields after JSON decode
- `disable_all` is cast via `filter_var(FILTER_VALIDATE_BOOLEAN)` to handle string `"true"`
- `canary_sites` and `disabled_plugins` are validated as arrays

If the API returns `"true"` (string) instead of `true` (boolean), the strict `true ===` comparison silently fails and the global auto-update kill switch would not engage during emergencies.

## Test plan
- [ ] Verify auto-update disable-all behavior with boolean `true` from API
- [ ] Verify kill switch still works if API returns string `"true"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data validation in the auto-update plugins system to ensure consistent processing of configuration settings from local and remote sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->