### PR TITLE
Fix: Version string parsing bounds check in auto-update delay

### DIFF
--- a/src/Modules/Autoupdates/Helpers.php
+++ b/src/Modules/Autoupdates/Helpers.php
@@ -61,7 +61,7 @@ class Helpers {
 		$update_version_parts    = explode( '.', $plugin_new_version );
 
 		// only apply delays to major and minor releases. let point releases (patches) go through.
-		if ( $installed_version_parts[0] !== $update_version_parts[0] || $installed_version_parts[1] !== $update_version_parts[1] ) {
+		if ( ( $installed_version_parts[0] ?? '0' ) !== ( $update_version_parts[0] ?? '0' ) || ( $installed_version_parts[1] ?? '0' ) !== ( $update_version_parts[1] ?? '0' ) ) {
 			$update_allowed_after = $this->get_delay_date( $plugin_slug, $plugin_new_version, $delay_days, $plugin_file );
 
 			if ( time() >= $update_allowed_after ) {


### PR DESCRIPTION
## Summary
- Added null coalescing for version part array access to prevent undefined key notices

Plugins with single-segment versions (e.g., `"2"`) cause `explode('.')` to return a single-element array. Accessing `[1]` on that array generates a PHP notice and returns `null`, causing incorrect delay behavior.

## Test plan
- [ ] Verify delay logic still works for standard semver versions (e.g., `1.2.3` → `1.3.0`)
- [ ] Verify no PHP notices for non-standard versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version comparison logic in auto-update checks to safely handle incomplete version strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->