### PR TITLE
Fix: Require explicit opt-in for WooCommerce and Sensei tracking

### DIFF
--- a/src/Modules/Tracking/Integrations/Sensei.php
+++ b/src/Modules/Tracking/Integrations/Sensei.php
@@ -20,7 +20,7 @@ class Sensei extends AbstractIntegration {
 	 * @version 1.0.0
 	 */
 	public function is_active(): bool {
-		return ! defined( 'WPCOMSP_SENSEI_TRACKING' ) || WPCOMSP_SENSEI_TRACKING;
+		return defined( 'WPCOMSP_SENSEI_TRACKING' ) && WPCOMSP_SENSEI_TRACKING;
 	}
 
 	/**

--- a/src/Modules/Tracking/Integrations/WooCommerce.php
+++ b/src/Modules/Tracking/Integrations/WooCommerce.php
@@ -20,7 +20,7 @@ class WooCommerce extends AbstractIntegration {
 	 * @version 1.0.0
 	 */
 	public function is_active(): bool {
-		return ! defined( 'WPCOMSP_WC_TRACKING' ) || WPCOMSP_WC_TRACKING;
+		return defined( 'WPCOMSP_WC_TRACKING' ) && WPCOMSP_WC_TRACKING;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Changed WooCommerce `is_active()` from `! defined('WPCOMSP_WC_TRACKING') || WPCOMSP_WC_TRACKING` to `defined('WPCOMSP_WC_TRACKING') && WPCOMSP_WC_TRACKING`
- Changed Sensei `is_active()` with the same pattern

All three tracking integrations (WC, Sensei, Bilmur) now consistently default to OFF and require explicit opt-in via constants.

**Breaking change:** Sites relying on the implicit ON default will need to define `WPCOMSP_WC_TRACKING` and/or `WPCOMSP_SENSEI_TRACKING` as `true` in wp-config.php.

## Test plan
- [ ] Verify WC tracking is OFF when constant is undefined
- [ ] Verify WC tracking is ON when `WPCOMSP_WC_TRACKING` is defined as `true`
- [ ] Same for Sensei tracking
- [ ] Verify Bilmur behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Sensei and WooCommerce tracking activation logic to require explicit configuration to be enabled, rather than defaulting to active when configuration is not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->