### PR TITLE
Fix: Add ext-sodium to composer.json requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
   ],
   "require": {
     "php": ">=8.3",
-    "ext-json": "*"
+    "ext-json": "*",
+    "ext-sodium": "*"
   },
   "require-dev": {
     "a8cteam51/team51-configs": "dev-trunk",


### PR DESCRIPTION
## Summary
- Added `"ext-sodium": "*"` to composer.json `require` section

The plugin uses libsodium functions for message encryption but didn't declare the dependency. This could allow installation on minimal PHP builds without sodium, causing runtime fatals.

## Test plan
- [ ] Run `composer install` — verify it succeeds with sodium extension present
- [ ] Verify `composer check-platform-reqs` lists ext-sodium

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system requirements to include the sodium extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->