### PR TITLE
Fix: Cache is_disabled() result in maybe_initialize()

### DIFF
--- a/src/Modules/AbstractModule.php
+++ b/src/Modules/AbstractModule.php
@@ -90,12 +90,12 @@ abstract class AbstractModule {
 			return;
 		}
 
-		if ( false !== $this->is_disabled() ) {
+		$is_disabled = $this->is_disabled();
+		if ( false !== $is_disabled ) {
 			add_action(
 				'admin_notices',
-				function () {
-					$error = $this->is_disabled();
-					if ( ! is_wp_error( $error ) ) {
+				function () use ( $is_disabled ) {
+					if ( ! is_wp_error( $is_disabled ) ) {
 						return;
 					}
 
@@ -104,7 +104,7 @@ abstract class AbstractModule {
 						__( '<strong>%1$s %2$s Module:</strong> %3$s', 'a8csp-atlantis' ),
 						a8csp_atlantis_get_plugin_metadata( 'Name' ),
 						esc_html( $this->get_name() ),
-						esc_html( $error->get_error_message() )
+						esc_html( $is_disabled->get_error_message() )
 					);
 
 					wp_admin_notice( $environment_error, array( 'type' => 'error' ) );


### PR DESCRIPTION
## Summary
- Stored `is_disabled()` result in a variable instead of calling it twice
- Captured the cached value in the admin_notices closure via `use()`

Avoids duplicate calls to `is_disabled()` which can involve database queries (e.g., Messages module checks `table_exists()`).

## Test plan
- [ ] Verify module disable notices still display correctly
- [ ] Verify non-production Tracking module still shows environment error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized module initialization logic to reduce redundant function calls and improve callback efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->