### PR TITLE
Fix: Harden singleton __wakeup visibility

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -77,8 +77,8 @@ class Plugin {
 	 *
 	 * @return  void
 	 */
-	public function __wakeup() {
-		/* Empty on purpose. */
+	private function __wakeup(): void {
+		throw new \RuntimeException( 'Cannot unserialize a singleton.' );
 	}
 
 	// endregion


### PR DESCRIPTION
## Summary
- Changed `__wakeup()` from `public` to `private` on Plugin singleton
- Added `RuntimeException` throw to prevent unserialization

## Test plan
- [ ] Verify plugin still initializes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)