### PR TITLE
Fix: Prune stale plugin delay entries during update cleanup

### DIFF
--- a/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
+++ b/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
@@ -508,6 +508,20 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 				foreach ( $options['plugins'] as $plugin ) {
 					$helpers->clear_plugin_delay( $plugin );
 				}
+
+				// Prune stale delay entries for plugins that are no longer installed.
+				$delays = get_option( 'plugin_update_delays', array() );
+				if ( is_array( $delays ) && array() !== $delays ) {
+					$installed_plugins = array_keys( get_plugins() );
+					$stale_keys        = array_diff( array_keys( $delays ), $installed_plugins );
+
+					if ( array() !== $stale_keys ) {
+						foreach ( $stale_keys as $stale_key ) {
+							unset( $delays[ $stale_key ] );
+						}
+						update_option( 'plugin_update_delays', $delays );
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Added garbage collection for plugin delay entries during update completion
- Removes delay entries for plugins that are no longer installed

Over time, `plugin_update_delays` option accumulates entries for uninstalled plugins. This runs during existing update cleanup and prunes entries not in `get_plugins()`.

## Test plan
- [ ] Verify delay data is still cleared after plugin updates
- [ ] Verify stale entries for removed plugins are cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)