### PR TITLE
Fix: Validate date format in team51-current-year shortcode

### DIFF
--- a/includes/module-colophon.php
+++ b/includes/module-colophon.php
@@ -139,7 +139,12 @@ if ( ! function_exists( 'team51_current_year_shortcode' ) ) :
 			'team51-current-year'
 		);
 
-		$current_year = gmdate( $atts['format'] );
+		$format = $atts['format'];
+		if ( 1 !== preg_match( '/^[YymndjDlFMGgHhisAaeIOPTZcUrWS]+$/', $format ) ) {
+			$format = 'Y';
+		}
+
+		$current_year = gmdate( $format );
 		return esc_html( $current_year );
 	}
 


### PR DESCRIPTION
## Summary
- Added whitelist validation of date format characters in `[team51-current-year]` shortcode
- Falls back to `'Y'` if format contains invalid characters

## Test plan
- [ ] Verify `[team51-current-year]` outputs current year
- [ ] Verify `[team51-current-year format="Y-m-d"]` works
- [ ] Verify invalid format falls back to year only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved validation for year display shortcode format attributes; invalid format characters now default to displaying the year only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->