### PR TITLE
Fix: Return UTC directly for zero-hour timezone offsets in Bilmur

### DIFF
--- a/src/Modules/Tracking/Integrations/Bilmur.php
+++ b/src/Modules/Tracking/Integrations/Bilmur.php
@@ -140,6 +140,9 @@ class Bilmur extends AbstractIntegration {
 			// For integer hour offsets, use "Etc/GMT(+|-)N".
 			// The sign is flipped to match how the Etc area is specced.
 			// This codepath is also the fallback when no city matches a fractional offset.
+			if ( 0 === $hours ) {
+				return 'UTC';
+			}
 			return 'Etc/GMT' . ( -1 === $sign ? '+' : '-' ) . $hours;
 		}
 
@@ -148,6 +151,9 @@ class Bilmur extends AbstractIntegration {
 			$sign  = '-' === $matches[1] ? -1 : 1;
 			$hours = intval( $matches[2], 10 );
 
+			if ( 0 === $hours ) {
+				return 'UTC';
+			}
 			return 'Etc/GMT' . ( -1 === $sign ? '+' : '-' ) . $hours;
 		}
 


### PR DESCRIPTION
## Summary
- Added early return of `'UTC'` when timezone offset hours are zero
- Prevents nonstandard `'Etc/GMT+0'` or `'Etc/GMT-0'` values

## Test plan
- [ ] Verify Bilmur timezone string is `'UTC'` when site is set to UTC+0
- [ ] Verify non-zero offsets still produce correct `Etc/GMT` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)