### PR TITLE
Lower PHP minimum requirement from 8.3 to 8.2

### DIFF
--- a/.github/workflows/codeception-tests.yml
+++ b/.github/workflows/codeception-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 8.3, 8.4 ]
+        php: [ 8.2, 8.3, 8.4 ]
         wp: [ null, WordPress/WordPress#master ]
 
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This file provides AI coding assistants with the context they need to work effec
 
 **Text domain:** `a8csp-atlantis`  
 **Namespace:** `A8C\SpecialProjects\Atlantis\`  
-**Requires:** WordPress 6.8+, PHP 8.3+
+**Requires:** WordPress 6.8+, PHP 8.2+
 
 ---
 
@@ -100,7 +100,7 @@ On activation, Atlantis checks legacy `plugin-autoupdate-filter` state:
 
 | Requirement | Version |
 | ----------- | ------- |
-| PHP | 8.3+ |
+| PHP | 8.2+ |
 | Node.js | 20+ |
 | npm | 10+ |
 | Docker | Required for integration and end-to-end tests |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - **Tags:** auto-updates, tracking, messages, colophon, site-management
 - **Requires at least:** 6.5
 - **Tested up to:** 6.8.1
-- **Requires PHP:** 8.3
+- **Requires PHP:** 8.2
 - **Stable tag:** 1.0.9
 - **License:** GPLv3 or later
 - **License URI:** [http://www.gnu.org/licenses/gpl-3.0.html](http://www.gnu.org/licenses/gpl-3.0.html)

--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -18,7 +18,7 @@
  * Version:                 1.0.9
  * Requires at least:       6.8
  * Tested up to:            6.8.1
- * Requires PHP:            8.3
+ * Requires PHP:            8.2
  * Author:                  Automattic Special Projects
  * Author URI:              https://specialprojects.automattic.com
  * License:                 GPL v3 or later

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     }
   ],
   "require": {
-    "php": ">=8.3",
+    "php": ">=8.2",
     "ext-json": "*"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b83e4342485a9f2de2232f5ad964589",
+    "content-hash": "be7b97c98f069a482ada68d11bd62857",
     "packages": [],
     "packages-dev": [
         {
@@ -24,7 +24,7 @@
             "require": {
                 "ext-json": "*",
                 "johnbillion/wp-compat": "^1",
-                "php": ">=8.3",
+                "php": ">=8.2",
                 "phpcompatibility/phpcompatibility-wp": "*",
                 "phpmd/phpmd": "^2",
                 "phpstan/extension-installer": "^1",
@@ -8326,7 +8326,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.3",
+        "php": ">=8.2",
         "ext-json": "*"
     },
     "platform-dev": {},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be7b97c98f069a482ada68d11bd62857",
+    "content-hash": "ddca9d116a0a792c08599731a6e95780",
     "packages": [],
     "packages-dev": [
         {

--- a/functions-bootstrap.php
+++ b/functions-bootstrap.php
@@ -114,7 +114,7 @@ function a8csp_atlantis_is_php_version_compatible( $min_php_version ) {
 function a8csp_atlantis_validate_requirements() {
 	$plugin_metadata = a8csp_atlantis_get_plugin_metadata();
 	if ( ! isset( $plugin_metadata['RequiresPHP'] ) || '' === $plugin_metadata['RequiresPHP'] ) {
-		$plugin_metadata['RequiresPHP'] = '8.3';
+		$plugin_metadata['RequiresPHP'] = '8.2';
 	}
 	if ( ! isset( $plugin_metadata['RequiresWP'] ) || '' === $plugin_metadata['RequiresWP'] ) {
 		$plugin_metadata['RequiresWP'] = '6.8';

--- a/src/Modules/Autoupdates/PluginFilterRules.php
+++ b/src/Modules/Autoupdates/PluginFilterRules.php
@@ -17,7 +17,7 @@ class PluginFilterRules {
 	 *
 	 * @var string
 	 */
-	public const string DISABLED_PLUGIN_FILTERS_OPTION = 'plugin_autoupdate_filter_disabled_plugins';
+	public const DISABLED_PLUGIN_FILTERS_OPTION = 'plugin_autoupdate_filter_disabled_plugins';
 
 	/**
 	 * Get a normalized list of plugin files for which filter logic is disabled.

--- a/src/Modules/Messages/CustomTable.php
+++ b/src/Modules/Messages/CustomTable.php
@@ -21,7 +21,7 @@ class CustomTable {
 	 *
 	 * @var string
 	 */
-	protected const string TABLE_NAME = 'a8csp_atlantis_messages';
+	protected const TABLE_NAME = 'a8csp_atlantis_messages';
 
 	/**
 	 * Current schema version.
@@ -29,7 +29,7 @@ class CustomTable {
 	 *
 	 * @var string Current schema version
 	 */
-	protected const string SCHEMA_VERSION = '1.0.0';
+	protected const SCHEMA_VERSION = '1.0.0';
 
 	// endregion
 


### PR DESCRIPTION
Related to #

## Proposed changes

* Remove typed class constants (`const string ...`) — a PHP 8.3-only feature — from `PluginFilterRules` and `CustomTable`
* Update minimum PHP version from 8.3 to 8.2 in plugin header, `composer.json`, `composer.lock`, `functions-bootstrap.php`, `README.md`, and `AGENTS.md`

## Why are these changes being made?

The only PHP 8.3-specific syntax in the codebase was 3 typed class constants. Removing the type from those constants makes the plugin compatible with PHP 8.2, which broadens the range of environments it can run on.

## Testing instructions

* Verify the plugin activates and runs on PHP 8.2
* Verify the plugin still works on PHP 8.3
* Check that the constants in `PluginFilterRules::DISABLED_PLUGIN_FILTERS_OPTION`, `CustomTable::TABLE_NAME`, and `CustomTable::SCHEMA_VERSION` behave identically (they're all string literals, so removing the type hint changes nothing at runtime)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated minimum PHP version requirement from 8.3 to 8.2 across documentation and configuration files.

* **Chores**
  * Expanded GitHub Actions test matrix to include PHP 8.2, improving compatibility testing coverage.

**Impact:** The plugin now supports PHP 8.2+, broadening its compatibility with additional PHP environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->