### PR TITLE
Fix Bilmur custom properties on Atomic sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 - **Contributors:** wpcomspecialprojects
 - **Tags:** auto-updates, tracking, messages, colophon, site-management
 - **Requires at least:** 6.5
-- **Tested up to:** 6.8.1
+- **Tested up to:** 6.9.4
 - **Requires PHP:** 8.2
-- **Stable tag:** 1.0.9
+- **Stable tag:** 1.1.0
 - **License:** GPLv3 or later
 - **License URI:** [http://www.gnu.org/licenses/gpl-3.0.html](http://www.gnu.org/licenses/gpl-3.0.html)
 

--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -3,7 +3,7 @@
  * The A8CSP Atlantis bootstrap file.
  *
  * @since       1.0.0
- * @version     1.0.9
+ * @version     1.1.0
  * @package     A8C\SpecialProjects\Plugins
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
@@ -15,7 +15,7 @@
  * Plugin URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Update URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Description:             Centralized site management for Team51.
- * Version:                 1.0.9
+ * Version:                 1.1.0
  * Requires at least:       6.8
  * Tested up to:            6.8.1
  * Requires PHP:            8.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a8csp-atlantis",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a8csp-atlantis",
-      "version": "1.0.9",
+      "version": "1.1.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "select2": "^4.1.0-rc.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a8csp-atlantis",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "A scaffold for A8C Special Projects plugins",
   "author": {
     "name": "A8C Special Projects Team",

--- a/src/Modules/Tracking/Integrations/Bilmur.php
+++ b/src/Modules/Tracking/Integrations/Bilmur.php
@@ -10,16 +10,24 @@ defined( 'ABSPATH' ) || exit;
  * Bilmur RUM Integration class.
  *
  * @since   1.0.0
- * @version 1.1.0
+ * @version 1.2.0
  */
 class Bilmur extends AbstractIntegration {
 	/**
 	 * {@inheritDoc}
 	 *
 	 * @since   1.0.0
-	 * @version 1.1.0
+	 * @version 1.2.0
 	 */
 	public function is_active(): bool {
+		// On sites where wpcomsh handles Bilmur, we only need custom properties defined.
+		if ( self::is_wpcomsh_bilmur_active() ) {
+			return defined( 'WPCOMSP_BILMUR_CUSTOM_PROPERTIES' )
+				&& is_array( WPCOMSP_BILMUR_CUSTOM_PROPERTIES )
+				&& array() !== WPCOMSP_BILMUR_CUSTOM_PROPERTIES;
+		}
+
+		// On non-wpcomsh sites (Pressable), require explicit opt-in.
 		if ( ! defined( 'WPCOMSP_BILMUR_TRACKING' ) || ! WPCOMSP_BILMUR_TRACKING ) {
 			return false;
 		}
@@ -35,9 +43,64 @@ class Bilmur extends AbstractIntegration {
 	 * {@inheritDoc}
 	 *
 	 * @since   1.0.0
-	 * @version 1.1.0
+	 * @version 1.2.0
 	 */
 	protected function initialize(): void {
+		// Always register the wpcomsh filter for Atomic compatibility (harmless on non-Atomic sites).
+		add_filter( 'wpcomsh_rum_kv', array( self::class, 'filter_wpcomsh_rum_kv' ), 10, 2 );
+
+		if ( ! self::is_wpcomsh_bilmur_active() ) {
+			$this->initialize_bilmur_output();
+		}
+	}
+
+	/**
+	 * Check if wpcomsh is handling Bilmur output.
+	 *
+	 * wpcomsh hooks its Bilmur output at wp_footer. If this function exists
+	 * and is hooked, we should not output our own script/meta tag.
+	 *
+	 * @since   1.2.0
+	 * @version 1.2.0
+	 *
+	 * @return bool
+	 */
+	private static function is_wpcomsh_bilmur_active(): bool {
+		return function_exists( 'wpcomsh_footer_rum_js' )
+			&& false !== has_action( 'wp_footer', 'wpcomsh_footer_rum_js' );
+	}
+
+	/**
+	 * Filter wpcomsh RUM key-value pairs to add custom properties on Atomic sites.
+	 *
+	 * This filter is provided by wpcomsh and allows us to inject custom properties
+	 * into the Bilmur data without duplicating the script or meta tag.
+	 *
+	 * @since   1.2.0
+	 * @version 1.2.0
+	 *
+	 * @param array<string, string> $kv      The existing key-value pairs.
+	 * @param string                $service The bilmur service name.
+	 *
+	 * @return array<string, string> The modified key-value pairs.
+	 */
+	public static function filter_wpcomsh_rum_kv( array $kv, string $service ): array {
+		$custom_properties = defined( 'WPCOMSP_BILMUR_CUSTOM_PROPERTIES' ) ? WPCOMSP_BILMUR_CUSTOM_PROPERTIES : array();
+
+		if ( is_array( $custom_properties ) ) {
+			$kv = array_merge( $kv, $custom_properties );
+		}
+
+		return $kv;
+	}
+
+	/**
+	 * Initialize Bilmur script and meta tag output for non-wpcomsh sites.
+	 *
+	 * @since   1.2.0
+	 * @version 1.2.0
+	 */
+	private function initialize_bilmur_output(): void {
 		add_action(
 			'wp_enqueue_scripts',
 			static function () {

--- a/src/Modules/Tracking/Integrations/Bilmur.php
+++ b/src/Modules/Tracking/Integrations/Bilmur.php
@@ -14,17 +14,27 @@ defined( 'ABSPATH' ) || exit;
  */
 class Bilmur extends AbstractIntegration {
 	/**
+	 * Custom properties to inject into wpcomsh's Bilmur RUM data on Atomic sites.
+	 *
+	 * @since   1.2.0
+	 * @version 1.2.0
+	 *
+	 * @var array<string, string>
+	 */
+	private static array $wpcomsh_custom_properties = array(
+		'wpcomsp' => '1',
+	);
+
+	/**
 	 * {@inheritDoc}
 	 *
 	 * @since   1.0.0
 	 * @version 1.2.0
 	 */
 	public function is_active(): bool {
-		// On sites where wpcomsh handles Bilmur, we only need custom properties defined.
+		// On Atomic sites where wpcomsh handles Bilmur, always activate to register the filter.
 		if ( self::is_wpcomsh_bilmur_active() ) {
-			return defined( 'WPCOMSP_BILMUR_CUSTOM_PROPERTIES' )
-				&& is_array( WPCOMSP_BILMUR_CUSTOM_PROPERTIES )
-				&& array() !== WPCOMSP_BILMUR_CUSTOM_PROPERTIES;
+			return true;
 		}
 
 		// On non-wpcomsh sites (Pressable), require explicit opt-in.
@@ -85,13 +95,7 @@ class Bilmur extends AbstractIntegration {
 	 * @return array<string, string> The modified key-value pairs.
 	 */
 	public static function filter_wpcomsh_rum_kv( array $kv, string $service ): array {
-		$custom_properties = defined( 'WPCOMSP_BILMUR_CUSTOM_PROPERTIES' ) ? WPCOMSP_BILMUR_CUSTOM_PROPERTIES : array();
-
-		if ( is_array( $custom_properties ) ) {
-			$kv = array_merge( $kv, $custom_properties );
-		}
-
-		return $kv;
+		return array_merge( $kv, self::$wpcomsh_custom_properties );
 	}
 
 	/**

--- a/src/Modules/Tracking/Integrations/Bilmur.php
+++ b/src/Modules/Tracking/Integrations/Bilmur.php
@@ -57,7 +57,7 @@ class Bilmur extends AbstractIntegration {
 	/**
 	 * Check if wpcomsh is handling Bilmur output.
 	 *
-	 * wpcomsh hooks its Bilmur output at wp_footer. If this function exists
+	 * Wpcomsh hooks its Bilmur output at wp_footer. If this function exists
 	 * and is hooked, we should not output our own script/meta tag.
 	 *
 	 * @since   1.2.0
@@ -145,7 +145,7 @@ class Bilmur extends AbstractIntegration {
 		add_action(
 			'wp_footer',
 			static function () {
-				$custom_properties = defined( 'WPCOMSP_BILMUR_CUSTOM_PROPERTIES' ) ? WPCOMSP_BILMUR_CUSTOM_PROPERTIES : array();
+				$custom_properties = defined( 'WPCOMSP_BILMUR_CUSTOM_PROPERTIES' ) && is_array( WPCOMSP_BILMUR_CUSTOM_PROPERTIES ) ? WPCOMSP_BILMUR_CUSTOM_PROPERTIES : array();
 
 				$custom_properties['woo_active'] = class_exists( 'WooCommerce' ) ? '1' : '0';
 


### PR DESCRIPTION
## Summary

- On Atomic sites, wpcomsh already outputs its own Bilmur `<meta>` tag and script via `wpcomsh_footer_rum_js()`. Atlantis was outputting a duplicate `<meta id="bilmur">` tag, causing its custom properties (`WPCOMSP_BILMUR_CUSTOM_PROPERTIES`) to be silently ignored.
- This fix detects wpcomsh's Bilmur via `function_exists()` + `has_action()` and uses the `wpcomsh_rum_kv` filter to inject custom properties into wpcomsh's output instead of duplicating the script/meta tag.
- On Pressable (non-Atomic) sites, behavior is unchanged — Atlantis continues to enqueue the script and output the meta tag as before.

## Changes

- **`Bilmur::is_active()`** — Added early-return path for Atomic: only requires `WPCOMSP_BILMUR_CUSTOM_PROPERTIES` to be a non-empty array.
- **`Bilmur::initialize()`** — Registers `wpcomsh_rum_kv` filter unconditionally; gates script/meta output behind `!is_wpcomsh_bilmur_active()`.
- **New `is_wpcomsh_bilmur_active()`** — Detects whether wpcomsh is handling Bilmur output.
- **New `filter_wpcomsh_rum_kv()`** — Merges custom properties into wpcomsh's RUM key-value pairs.
- **New `initialize_bilmur_output()`** — Extracted existing script/meta logic (unchanged behavior).
- **Version bump** — `1.0.9` → `1.1.0`

## Test plan

- [ ] On an Atomic site with `WPCOMSP_BILMUR_CUSTOM_PROPERTIES` defined: verify custom properties appear in wpcomsh's Bilmur output (no duplicate `<meta id="bilmur">` tag)
- [ ] On a Pressable site: verify existing Bilmur behavior is unchanged (script enqueued, meta tag output, WP Rocket compat)
- [ ] On a non-production environment: verify the Tracking module remains disabled (existing gate)
- [ ] `composer run lint:php` passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bilmur tracking now auto-includes Atomic/managed custom properties and adapts activation for managed outputs.

* **Bug Fixes**
  * Avoids emitting duplicate or incorrect Bilmur script/meta when a managed output path is present; prevents non-array custom-property values from being used.

* **Chores**
  * Version bumps across plugin, package, and integration; documentation updated for WordPress compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->