### PR TITLE
Add REST endpoint exposing Atlantis plugin and module status

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 - **Contributors:** wpcomspecialprojects
 - **Tags:** auto-updates, tracking, messages, colophon, site-management
 - **Requires at least:** 6.5
-- **Tested up to:** 6.9.4
+- **Tested up to:** 7.0
 - **Requires PHP:** 8.2
-- **Stable tag:** 1.1.0
+- **Stable tag:** 1.2.0
 - **License:** GPLv3 or later
 - **License URI:** [http://www.gnu.org/licenses/gpl-3.0.html](http://www.gnu.org/licenses/gpl-3.0.html)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 - **Contributors:** wpcomspecialprojects
 - **Tags:** auto-updates, tracking, messages, colophon, site-management
-- **Requires at least:** 6.5
+- **Requires at least:** 6.8
 - **Tested up to:** 7.0
 - **Requires PHP:** 8.2
 - **Stable tag:** 1.2.0

--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -3,7 +3,7 @@
  * The A8CSP Atlantis bootstrap file.
  *
  * @since       1.0.0
- * @version     1.1.0
+ * @version     1.2.0
  * @package     A8C\SpecialProjects\Plugins
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
@@ -15,9 +15,9 @@
  * Plugin URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Update URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Description:             Centralized site management for Team51.
- * Version:                 1.1.0
+ * Version:                 1.2.0
  * Requires at least:       6.8
- * Tested up to:            6.8.1
+ * Tested up to:            7.0
  * Requires PHP:            8.2
  * Author:                  Automattic Special Projects
  * Author URI:              https://specialprojects.automattic.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a8csp-atlantis",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a8csp-atlantis",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "select2": "^4.1.0-rc.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a8csp-atlantis",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A scaffold for A8C Special Projects plugins",
   "author": {
     "name": "A8C Special Projects Team",

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2,6 +2,8 @@
 
 namespace A8C\SpecialProjects\Atlantis;
 
+use A8C\SpecialProjects\Atlantis\REST\Status_Controller;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -42,6 +44,16 @@ class Plugin {
 	 * @var Settings
 	 */
 	public Settings $settings;
+
+	/**
+	 * The status REST controller.
+	 *
+	 * @since   1.2.0
+	 * @version 1.2.0
+	 *
+	 * @var Status_Controller
+	 */
+	public Status_Controller $status_controller;
 
 	// endregion
 
@@ -132,6 +144,9 @@ class Plugin {
 
 		$this->settings = new Settings();
 		$this->settings->initialize();
+
+		$this->status_controller = new Status_Controller();
+		$this->status_controller->initialize();
 	}
 
 	// endregion

--- a/src/REST/Status_Controller.php
+++ b/src/REST/Status_Controller.php
@@ -3,6 +3,7 @@
 namespace A8C\SpecialProjects\Atlantis\REST;
 
 use A8C\SpecialProjects\Atlantis\Message_Query;
+use A8C\SpecialProjects\Atlantis\Modules\Messages\CustomTable;
 use A8C\SpecialProjects\Atlantis\Plugin;
 
 defined( 'ABSPATH' ) || exit;
@@ -67,9 +68,14 @@ class Status_Controller {
 	 * Permission check: only site admins (or equivalents authenticated via
 	 * Jetpack-tunneled WPCOM calls) may read the status.
 	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @param \WP_REST_Request $request The REST request (unused; declared for the
+	 *                                  conventional REST callback signature).
+	 *
 	 * @return true|\WP_Error
 	 */
-	public function get_item_permissions_check(): true|\WP_Error {
+	public function get_item_permissions_check( \WP_REST_Request $request ): true|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		if ( ! \current_user_can( 'manage_options' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
@@ -84,9 +90,14 @@ class Status_Controller {
 	/**
 	 * Returns the plugin and module status payload.
 	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @param \WP_REST_Request $request The REST request (unused; declared for the
+	 *                                  conventional REST callback signature).
+	 *
 	 * @return \WP_REST_Response
 	 */
-	public function get_item(): \WP_REST_Response {
+	public function get_item( \WP_REST_Request $request ): \WP_REST_Response { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		$modules = array();
 
 		foreach ( Plugin::get_instance()->modules->modules as $key => $module ) {
@@ -117,6 +128,10 @@ class Status_Controller {
 	 * @return int
 	 */
 	private function count_messages(): int {
+		if ( ! CustomTable::table_exists() ) {
+			return 0;
+		}
+
 		try {
 			$query = new Message_Query( array( 'per_page' => 1 ) );
 			return $query->found_rows;

--- a/src/REST/Status_Controller.php
+++ b/src/REST/Status_Controller.php
@@ -1,0 +1,109 @@
+<?php declare( strict_types=1 );
+
+namespace A8C\SpecialProjects\Atlantis\REST;
+
+use A8C\SpecialProjects\Atlantis\Plugin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST controller that exposes Atlantis plugin and module status for
+ * fleet-wide reporting (e.g. via OpsOasis and the team51 CLI).
+ *
+ * @since   1.2.0
+ * @version 1.2.0
+ */
+class Status_Controller {
+	/**
+	 * REST namespace.
+	 *
+	 * @var string
+	 */
+	private string $namespace = 'a8csp-atlantis/v1';
+
+	/**
+	 * REST base for this controller.
+	 *
+	 * @var string
+	 */
+	private string $rest_base = 'status';
+
+	// region METHODS
+
+	/**
+	 * Registers the controller hooks.
+	 *
+	 * @return void
+	 */
+	public function initialize(): void {
+		\add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Registers the REST routes for this controller.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		\register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'callback'            => array( $this, 'get_item' ),
+				),
+			)
+		);
+	}
+
+	// endregion
+
+	// region CALLBACKS
+
+	/**
+	 * Permission check: only site admins (or equivalents authenticated via
+	 * Jetpack-tunneled WPCOM calls) may read the status.
+	 *
+	 * @return true|\WP_Error
+	 */
+	public function get_item_permissions_check(): true|\WP_Error {
+		if ( ! \current_user_can( 'manage_options' ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				\__( 'You do not have permission to read Atlantis status.', 'a8csp-atlantis' ),
+				array( 'status' => \rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the plugin and module status payload.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function get_item(): \WP_REST_Response {
+		$modules = array();
+
+		foreach ( Plugin::get_instance()->modules->modules as $key => $module ) {
+			$modules[ $key ] = array(
+				'name'    => $module->get_name(),
+				'enabled' => $module->is_active(),
+			);
+		}
+
+		return \rest_ensure_response(
+			array(
+				'plugin'  => array(
+					'version' => \a8csp_atlantis_get_plugin_version(),
+				),
+				'modules' => $modules,
+			)
+		);
+	}
+
+	// endregion
+}

--- a/src/REST/Status_Controller.php
+++ b/src/REST/Status_Controller.php
@@ -2,6 +2,7 @@
 
 namespace A8C\SpecialProjects\Atlantis\REST;
 
+use A8C\SpecialProjects\Atlantis\Message_Query;
 use A8C\SpecialProjects\Atlantis\Plugin;
 
 defined( 'ABSPATH' ) || exit;
@@ -95,6 +96,10 @@ class Status_Controller {
 			);
 		}
 
+		if ( isset( $modules['messages'] ) ) {
+			$modules['messages']['count'] = $this->count_messages();
+		}
+
 		return \rest_ensure_response(
 			array(
 				'plugin'  => array(
@@ -103,6 +108,21 @@ class Status_Controller {
 				'modules' => $modules,
 			)
 		);
+	}
+
+	/**
+	 * Returns the number of stored custom messages, or 0 if the count cannot
+	 * be determined (table missing, module failed to initialise, etc.).
+	 *
+	 * @return int
+	 */
+	private function count_messages(): int {
+		try {
+			$query = new Message_Query( array( 'per_page' => 1 ) );
+			return $query->found_rows;
+		} catch ( \Throwable $t ) {
+			return 0;
+		}
 	}
 
 	// endregion


### PR DESCRIPTION
## Summary

- Adds `GET /wp-json/a8csp-atlantis/v1/status`, a small read-only endpoint that returns the plugin version and the enabled/disabled state of each registered module.
- The `messages` module entry also reports a `count` of stored custom messages, so fleet reports can answer "which sites have custom messages set" without per-site WP-CLI access.
- Permission callback: `manage_options` — satisfied by Jetpack-tunneled WPCOM calls (which authenticate as a site admin) and rejects unauthenticated callers.
- Module state is read from each module's existing `is_active()`, so the report tracks whatever the module itself treats as canonical (including future `is_mandatory()` overrides).
- Bumps the plugin to **1.2.0** and "Tested up to" to **7.0** (plugin header, README, and `package.json` / `package-lock.json`).

## Why

Unblocks fleet-wide "which sites have the Autoupdate Filter module enabled?" reporting across 1,000+ Jetpack-connected sites without per-site WP-CLI access. The endpoint is consumed by:

- A companion OpsOasis PR ([a8cteam51/opsoasis#177](https://github.com/a8cteam51/opsoasis/pull/177)) that adds a batch proxy at `sites/batch/atlantis-status`.
- A companion team51-cli PR ([a8cteam51/team51-cli#125](https://github.com/a8cteam51/team51-cli/pull/125)) adding the `wpcom:atlantis-status` command, including a `Custom Msgs` column and `--with-messages-only` filter that read the new `messages.count` field.

The architecture mirrors the existing `sites/batch/plugins` → `jetpack/v4/plugins` flow — same plumbing, just pointed at this new Atlantis endpoint.

## Response shape

```json
{
  "plugin": { "version": "1.2.0" },
  "modules": {
    "messages":    { "name": "Messages",    "enabled": true, "count": 3 },
    "colophon":    { "name": "Colophon",    "enabled": true },
    "tracking":    { "name": "Tracking",    "enabled": true },
    "autoupdates": { "name": "Autoupdates", "enabled": true }
  }
}
```

`modules.messages.count` falls back to `0` if the count cannot be determined (e.g. table missing on a partially-initialised site) — the endpoint never errors on that path.

Sites without Atlantis return a standard 404 from the REST router — handled cleanly by the consuming CLI as `not installed`.

## Scope notes

Intentionally minimal — no `?detail=full`, no decrypted message contents, no sub-settings. The shape leaves room to grow (e.g. message titles/types, plugin deactivation diagnostics, per-module sub-settings) as later iterations need them.

## Test plan

- [ ] Activate this branch on a test site.
- [ ] Verify the route is registered. Easiest local check, since `wp rest` is not built into WP-CLI:
      `wp eval 'wp_set_current_user(1); echo wp_json_encode( rest_do_request("/a8csp-atlantis/v1/status")->get_data(), JSON_PRETTY_PRINT );'`
- [ ] With zero custom messages stored, confirm `modules.messages.count` is `0`.
- [ ] Create one or more custom messages from the Atlantis admin UI; re-fetch and confirm `modules.messages.count` matches.
- [ ] Disable the Autoupdate Filter module from the Atlantis settings UI; re-fetch the endpoint and confirm `modules.autoupdates.enabled` is `false`.
- [ ] Re-enable and confirm it flips back to `true`.
- [ ] Hit the endpoint as a non-admin user and confirm 401/403 (permission_callback rejects).
- [ ] Deactivate the Atlantis plugin entirely and confirm the route is gone (404).
- [ ] Smoke-test alongside the OpsOasis PR ([opsoasis#177](https://github.com/a8cteam51/opsoasis/pull/177)) by calling `POST /wpcomsp/wpcom/v1/sites/batch/atlantis-status` with the test site's ID; expect the same JSON shape inside the batch envelope.
- [ ] Verify the plugin header reports `Version: 1.2.0` and `Tested up to: 7.0`, and that the README's stable tag matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a REST API endpoint to retrieve Atlantis plugin status (version and modules), including per-module display name, enabled/active state, and message count when applicable. Endpoint is registered at initialization and requires admin permissions.
* **Documentation**
  * Bumped plugin and package versions to 1.2.0 and updated compatibility/testing metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/a8cteam51/a8csp-atlantis/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->