### PR TITLE
Add WP-CLI commands for Atlantis modules and messages

### DIFF
--- a/src/CLI/Message_Command.php
+++ b/src/CLI/Message_Command.php
@@ -4,6 +4,7 @@ namespace A8C\SpecialProjects\Atlantis\CLI;
 
 use A8C\SpecialProjects\Atlantis\Message;
 use A8C\SpecialProjects\Atlantis\Message_Query;
+use A8C\SpecialProjects\Atlantis\Modules\Messages\CustomTable;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -24,8 +25,8 @@ defined( 'ABSPATH' ) || exit;
  *     # Inspect a single message including its decrypted content.
  *     $ wp atlantis message get 42 --fields=id,title,type,status,content
  *
- * @since   1.3.0
- * @version 1.3.0
+ * @since   1.2.0
+ * @version 1.2.0
  */
 class Message_Command {
 	/**
@@ -139,13 +140,20 @@ class Message_Command {
 	 * @param array<string, string|bool> $assoc_args Flags.
 	 */
 	public function list_( array $args, array $assoc_args ): void {
+		$this->require_messages_table();
+
 		$full = isset( $assoc_args['full'] ) && true === $assoc_args['full'];
+
+		$per_page = isset( $assoc_args['per_page'] ) ? (int) $assoc_args['per_page'] : ( $full ? -1 : 20 );
+		if ( 0 === $per_page || $per_page < -1 ) {
+			\WP_CLI::error( '--per_page must be a positive integer or -1 (no limit).' );
+		}
 
 		$query_args = array(
 			'type'     => $assoc_args['type'] ?? null,
 			'status'   => $assoc_args['status'] ?? null,
 			'search'   => (string) ( $assoc_args['search'] ?? '' ),
-			'per_page' => isset( $assoc_args['per_page'] ) ? (int) $assoc_args['per_page'] : ( $full ? -1 : 20 ),
+			'per_page' => $per_page,
 			'paged'    => (int) ( $assoc_args['paged'] ?? 1 ),
 			'orderby'  => (string) ( $assoc_args['orderby'] ?? 'created_at' ),
 			'order'    => (string) ( $assoc_args['order'] ?? 'DESC' ),
@@ -194,6 +202,8 @@ class Message_Command {
 	 * @param array<string, string|bool> $assoc_args Flags.
 	 */
 	public function get( array $args, array $assoc_args ): void {
+		$this->require_messages_table();
+
 		$id = (int) ( $args[0] ?? 0 );
 		if ( 0 >= $id ) {
 			\WP_CLI::error( 'A positive integer message ID is required.' );
@@ -213,6 +223,18 @@ class Message_Command {
 	// endregion
 
 	// region HELPERS
+
+	/**
+	 * Bails with a clean `WP_CLI::error()` when the messages table is missing,
+	 * preventing a downstream `$wpdb` null result from blowing up `Message_Query`.
+	 *
+	 * @return void
+	 */
+	private function require_messages_table(): void {
+		if ( ! CustomTable::table_exists() ) {
+			\WP_CLI::error( 'The Atlantis messages table does not exist on this site. The Messages module may have failed to initialise.' );
+		}
+	}
 
 	/**
 	 * Resolves and validates the requested field list.

--- a/src/CLI/Message_Command.php
+++ b/src/CLI/Message_Command.php
@@ -1,0 +1,263 @@
+<?php declare( strict_types=1 );
+
+namespace A8C\SpecialProjects\Atlantis\CLI;
+
+use A8C\SpecialProjects\Atlantis\Message;
+use A8C\SpecialProjects\Atlantis\Message_Query;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Inspect Atlantis custom messages from the command line.
+ *
+ * ## EXAMPLES
+ *
+ *     # List the 20 most recent messages.
+ *     $ wp atlantis message list
+ *
+ *     # List every message as JSON.
+ *     $ wp atlantis message list --per_page=-1 --format=json
+ *
+ *     # Filter by type and status.
+ *     $ wp atlantis message list --type=warning --status=active
+ *
+ *     # Inspect a single message including its decrypted content.
+ *     $ wp atlantis message get 42 --fields=id,title,type,status,content
+ *
+ * @since   1.3.0
+ * @version 1.3.0
+ */
+class Message_Command {
+	/**
+	 * Default fields returned by `list` and `get`.
+	 *
+	 * @var array<int, string>
+	 */
+	private const DEFAULT_FIELDS = array( 'id', 'title', 'type', 'status', 'created_at' );
+
+	/**
+	 * All fields a message can be projected onto.
+	 *
+	 * @var array<int, string>
+	 */
+	private const AVAILABLE_FIELDS = array(
+		'id',
+		'title',
+		'type',
+		'status',
+		'content',
+		'locations',
+		'exclusions',
+		'created_at',
+		'updated_at',
+	);
+
+	// region SUBCOMMANDS
+
+	/**
+	 * Lists custom messages from the Atlantis messages table.
+	 *
+	 * Content is decrypted only when explicitly requested via `--fields`.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--type=<type>]
+	 * : Filter by message type (exact match).
+	 *
+	 * [--status=<status>]
+	 * : Filter by message status (exact match).
+	 *
+	 * [--search=<term>]
+	 * : Substring match across title, type, status, locations, exclusions.
+	 *
+	 * [--per_page=<n>]
+	 * : Maximum rows to return. Use -1 for no limit.
+	 * ---
+	 * default: 20
+	 * ---
+	 *
+	 * [--paged=<n>]
+	 * : Page number when paginating.
+	 * ---
+	 * default: 1
+	 * ---
+	 *
+	 * [--orderby=<field>]
+	 * : Field to sort by.
+	 * ---
+	 * default: created_at
+	 * options:
+	 *   - title
+	 *   - content
+	 *   - type
+	 *   - status
+	 *   - locations
+	 *   - exclusions
+	 *   - created_at
+	 *   - updated_at
+	 * ---
+	 *
+	 * [--order=<direction>]
+	 * : Sort direction.
+	 * ---
+	 * default: DESC
+	 * options:
+	 *   - ASC
+	 *   - DESC
+	 * ---
+	 *
+	 * [--fields=<fields>]
+	 * : Comma-separated list of fields to show. Available: id, title, type,
+	 *   status, content, locations, exclusions, created_at, updated_at.
+	 * ---
+	 * default: id,title,type,status,created_at
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Render output in the given format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 *   - count
+	 *   - ids
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp atlantis message list
+	 *     $ wp atlantis message list --type=warning --format=json
+	 *     $ wp atlantis message list --per_page=-1 --fields=id,title
+	 *
+	 * @subcommand list
+	 *
+	 * @param array<int, string>         $args       Positional args (unused).
+	 * @param array<string, string|bool> $assoc_args Flags.
+	 */
+	public function list_( array $args, array $assoc_args ): void {
+		$query_args = array(
+			'type'     => $assoc_args['type'] ?? null,
+			'status'   => $assoc_args['status'] ?? null,
+			'search'   => (string) ( $assoc_args['search'] ?? '' ),
+			'per_page' => (int) ( $assoc_args['per_page'] ?? 20 ),
+			'paged'    => (int) ( $assoc_args['paged'] ?? 1 ),
+			'orderby'  => (string) ( $assoc_args['orderby'] ?? 'created_at' ),
+			'order'    => (string) ( $assoc_args['order'] ?? 'DESC' ),
+		);
+
+		$query = new Message_Query( $query_args );
+
+		$fields = $this->resolve_fields( $assoc_args );
+		$rows   = \array_map( fn( Message $m ) => $this->message_to_row( $m, $fields ), $query->get_results() );
+
+		$formatter = new \WP_CLI\Formatter( $assoc_args, $fields );
+		$formatter->display_items( $rows );
+	}
+
+	/**
+	 * Fetches a single message by ID.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <id>
+	 * : The numeric message ID.
+	 *
+	 * [--fields=<fields>]
+	 * : Comma-separated list of fields to show.
+	 * ---
+	 * default: id,title,type,status,created_at
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Render output in the given format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp atlantis message get 42
+	 *     $ wp atlantis message get 42 --fields=id,title,content --format=json
+	 *
+	 * @param array<int, string>         $args       Positional args: <id>.
+	 * @param array<string, string|bool> $assoc_args Flags.
+	 */
+	public function get( array $args, array $assoc_args ): void {
+		$id = (int) ( $args[0] ?? 0 );
+		if ( 0 >= $id ) {
+			\WP_CLI::error( 'A positive integer message ID is required.' );
+		}
+
+		try {
+			$message = new Message( $id );
+		} catch ( \InvalidArgumentException $e ) {
+			\WP_CLI::error( \sprintf( 'No message found with ID %d.', $id ) );
+		}
+
+		$fields    = $this->resolve_fields( $assoc_args );
+		$formatter = new \WP_CLI\Formatter( $assoc_args, $fields );
+		$formatter->display_items( array( $this->message_to_row( $message, $fields ) ) );
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Resolves and validates the requested field list.
+	 *
+	 * @param array<string, string|bool> $assoc_args Flags.
+	 *
+	 * @return array<int, string>
+	 */
+	private function resolve_fields( array $assoc_args ): array {
+		$fields = isset( $assoc_args['fields'] )
+			? \array_map( 'trim', \explode( ',', (string) $assoc_args['fields'] ) )
+			: self::DEFAULT_FIELDS;
+
+		$unknown = \array_diff( $fields, self::AVAILABLE_FIELDS );
+		if ( 0 < \count( $unknown ) ) {
+			\WP_CLI::error(
+				\sprintf(
+					'Unknown field(s): %s. Available: %s.',
+					\implode( ', ', $unknown ),
+					\implode( ', ', self::AVAILABLE_FIELDS )
+				)
+			);
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Projects a Message onto the requested field list with display-safe values.
+	 *
+	 * @param Message            $message Message instance.
+	 * @param array<int, string> $fields  Fields to include.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function message_to_row( Message $message, array $fields ): array {
+		$row = array();
+		foreach ( $fields as $field ) {
+			// Field names are validated against AVAILABLE_FIELDS by resolve_fields() before reaching here.
+			$value = $message->$field; // @phpstan-ignore property.dynamicName
+			if ( \in_array( $field, array( 'locations', 'exclusions' ), true ) && \is_array( $value ) ) {
+				$value = \wp_json_encode( $value );
+			}
+			$row[ $field ] = $value;
+		}
+
+		return $row;
+	}
+
+	// endregion
+}

--- a/src/CLI/Message_Command.php
+++ b/src/CLI/Message_Command.php
@@ -71,10 +71,7 @@ class Message_Command {
 	 * : Substring match across title, type, status, locations, exclusions.
 	 *
 	 * [--per_page=<n>]
-	 * : Maximum rows to return. Use -1 for no limit.
-	 * ---
-	 * default: 20
-	 * ---
+	 * : Maximum rows to return. Defaults to 20. Use -1 for no limit.
 	 *
 	 * [--paged=<n>]
 	 * : Page number when paginating.
@@ -109,9 +106,7 @@ class Message_Command {
 	 * [--fields=<fields>]
 	 * : Comma-separated list of fields to show. Available: id, title, type,
 	 *   status, content, locations, exclusions, created_at, updated_at.
-	 * ---
-	 * default: id,title,type,status,created_at
-	 * ---
+	 *   Defaults to id,title,type,status,created_at (or all fields with --full).
 	 *
 	 * [--format=<format>]
 	 * : Render output in the given format.
@@ -126,11 +121,17 @@ class Message_Command {
 	 *   - ids
 	 * ---
 	 *
+	 * [--full]
+	 * : Shortcut for "all messages, all columns" — equivalent to
+	 *   `--per_page=-1 --fields=id,title,type,status,content,locations,exclusions,created_at,updated_at`.
+	 *   Explicit `--per_page` or `--fields` overrides the corresponding default.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp atlantis message list
 	 *     $ wp atlantis message list --type=warning --format=json
 	 *     $ wp atlantis message list --per_page=-1 --fields=id,title
+	 *     $ wp atlantis message list --full --format=json
 	 *
 	 * @subcommand list
 	 *
@@ -138,11 +139,13 @@ class Message_Command {
 	 * @param array<string, string|bool> $assoc_args Flags.
 	 */
 	public function list_( array $args, array $assoc_args ): void {
+		$full = isset( $assoc_args['full'] ) && true === $assoc_args['full'];
+
 		$query_args = array(
 			'type'     => $assoc_args['type'] ?? null,
 			'status'   => $assoc_args['status'] ?? null,
 			'search'   => (string) ( $assoc_args['search'] ?? '' ),
-			'per_page' => (int) ( $assoc_args['per_page'] ?? 20 ),
+			'per_page' => isset( $assoc_args['per_page'] ) ? (int) $assoc_args['per_page'] : ( $full ? -1 : 20 ),
 			'paged'    => (int) ( $assoc_args['paged'] ?? 1 ),
 			'orderby'  => (string) ( $assoc_args['orderby'] ?? 'created_at' ),
 			'order'    => (string) ( $assoc_args['order'] ?? 'DESC' ),
@@ -150,7 +153,7 @@ class Message_Command {
 
 		$query = new Message_Query( $query_args );
 
-		$fields = $this->resolve_fields( $assoc_args );
+		$fields = $this->resolve_fields( $assoc_args, $full ? self::AVAILABLE_FIELDS : self::DEFAULT_FIELDS );
 		$rows   = \array_map( fn( Message $m ) => $this->message_to_row( $m, $fields ), $query->get_results() );
 
 		$formatter = new \WP_CLI\Formatter( $assoc_args, $fields );
@@ -202,7 +205,7 @@ class Message_Command {
 			\WP_CLI::error( \sprintf( 'No message found with ID %d.', $id ) );
 		}
 
-		$fields    = $this->resolve_fields( $assoc_args );
+		$fields    = $this->resolve_fields( $assoc_args, self::DEFAULT_FIELDS );
 		$formatter = new \WP_CLI\Formatter( $assoc_args, $fields );
 		$formatter->display_items( array( $this->message_to_row( $message, $fields ) ) );
 	}
@@ -215,13 +218,14 @@ class Message_Command {
 	 * Resolves and validates the requested field list.
 	 *
 	 * @param array<string, string|bool> $assoc_args Flags.
+	 * @param array<int, string>         $defaults   Fields to use when `--fields` is absent.
 	 *
 	 * @return array<int, string>
 	 */
-	private function resolve_fields( array $assoc_args ): array {
+	private function resolve_fields( array $assoc_args, array $defaults ): array {
 		$fields = isset( $assoc_args['fields'] )
 			? \array_map( 'trim', \explode( ',', (string) $assoc_args['fields'] ) )
-			: self::DEFAULT_FIELDS;
+			: $defaults;
 
 		$unknown = \array_diff( $fields, self::AVAILABLE_FIELDS );
 		if ( 0 < \count( $unknown ) ) {

--- a/src/CLI/Module_Command.php
+++ b/src/CLI/Module_Command.php
@@ -24,8 +24,8 @@ defined( 'ABSPATH' ) || exit;
  *     # Get a single module's state as JSON for scripting.
  *     $ wp atlantis module status autoupdates --format=json
  *
- * @since   1.3.0
- * @version 1.3.0
+ * @since   1.2.0
+ * @version 1.2.0
  */
 class Module_Command {
 	/**
@@ -210,6 +210,7 @@ class Module_Command {
 			$module = $modules[ $key ];
 			if ( $module->is_active() === $enabled ) {
 				\WP_CLI::log( \sprintf( "Module '%s' is already %s.", $key, $verb_ing ) );
+				$this->maybe_warn_environment_disabled( $key, $module, $enabled );
 				continue;
 			}
 
@@ -221,15 +222,34 @@ class Module_Command {
 			}
 
 			\WP_CLI::success( \sprintf( "Module '%s' %s.", $key, $verb_past ) );
-
-			$environment = $module->is_disabled();
-			if ( $enabled && \is_wp_error( $environment ) ) {
-				\WP_CLI::warning( \sprintf( "Module '%s' is environmentally disabled and will stay dormant: %s", $key, $environment->get_error_message() ) );
-			}
+			$this->maybe_warn_environment_disabled( $key, $module, $enabled );
 		}
 
 		if ( 0 < $failures ) {
 			\WP_CLI::halt( 1 );
+		}
+	}
+
+	/**
+	 * Emits a warning when activating a module that is environmentally disabled.
+	 *
+	 * Fired regardless of whether `set_enabled()` changed the stored flag, so
+	 * users see the warning even when the module is already "active" in settings.
+	 *
+	 * @param string         $key     Module key.
+	 * @param AbstractModule $module  Module instance.
+	 * @param bool           $enabled Target state passed to bulk_set_enabled().
+	 *
+	 * @return void
+	 */
+	private function maybe_warn_environment_disabled( string $key, AbstractModule $module, bool $enabled ): void {
+		if ( ! $enabled ) {
+			return;
+		}
+
+		$environment = $module->is_disabled();
+		if ( \is_wp_error( $environment ) ) {
+			\WP_CLI::warning( \sprintf( "Module '%s' is environmentally disabled and will stay dormant: %s", $key, $environment->get_error_message() ) );
 		}
 	}
 

--- a/src/CLI/Module_Command.php
+++ b/src/CLI/Module_Command.php
@@ -1,0 +1,287 @@
+<?php declare( strict_types=1 );
+
+namespace A8C\SpecialProjects\Atlantis\CLI;
+
+use A8C\SpecialProjects\Atlantis\Modules\AbstractModule;
+use A8C\SpecialProjects\Atlantis\Plugin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manage Atlantis modules from the command line.
+ *
+ * ## EXAMPLES
+ *
+ *     # List every module and whether it's enabled.
+ *     $ wp atlantis module list
+ *
+ *     # Activate one or more modules.
+ *     $ wp atlantis module activate autoupdates messages
+ *
+ *     # Deactivate a module.
+ *     $ wp atlantis module deactivate tracking
+ *
+ *     # Get a single module's state as JSON for scripting.
+ *     $ wp atlantis module status autoupdates --format=json
+ *
+ * @since   1.3.0
+ * @version 1.3.0
+ */
+class Module_Command {
+	/**
+	 * Default fields returned by `list` and `status`.
+	 *
+	 * @var array<int, string>
+	 */
+	private const DEFAULT_FIELDS = array( 'key', 'name', 'enabled', 'mandatory', 'environment' );
+
+	// region SUBCOMMANDS
+
+	/**
+	 * Lists every registered Atlantis module.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--fields=<fields>]
+	 * : Comma-separated list of fields to show.
+	 * ---
+	 * default: key,name,enabled,mandatory,environment
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Render output in the given format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 *   - count
+	 * ---
+	 *
+	 * ## AVAILABLE FIELDS
+	 *
+	 * * key         - Module identifier used by activate/deactivate.
+	 * * name        - Human-readable module name.
+	 * * enabled     - Whether the module is currently active.
+	 * * mandatory   - Whether the module is mandatory (cannot be disabled).
+	 * * environment - Reason the module is blocked by environment, if any.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp atlantis module list
+	 *     $ wp atlantis module list --fields=key,enabled --format=csv
+	 *
+	 * @subcommand list
+	 *
+	 * @param array<int, string>         $args       Positional args (unused).
+	 * @param array<string, string|bool> $assoc_args Flags.
+	 */
+	public function list_( array $args, array $assoc_args ): void {
+		$rows = array();
+		foreach ( $this->get_modules() as $key => $module ) {
+			$rows[] = $this->module_to_row( $key, $module );
+		}
+
+		$fields = isset( $assoc_args['fields'] )
+			? \array_map( 'trim', \explode( ',', (string) $assoc_args['fields'] ) )
+			: self::DEFAULT_FIELDS;
+
+		$formatter = new \WP_CLI\Formatter( $assoc_args, $fields );
+		$formatter->display_items( $rows );
+	}
+
+	/**
+	 * Shows the status of a single module.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <key>
+	 * : Module key (e.g. `messages`, `autoupdates`).
+	 *
+	 * [--fields=<fields>]
+	 * : Comma-separated list of fields to show.
+	 * ---
+	 * default: key,name,enabled,mandatory,environment
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Render output in the given format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp atlantis module status autoupdates
+	 *     $ wp atlantis module status messages --format=json
+	 *
+	 * @param array<int, string>         $args       Positional args: <key>.
+	 * @param array<string, string|bool> $assoc_args Flags.
+	 */
+	public function status( array $args, array $assoc_args ): void {
+		$module = $this->require_module( $args[0] ?? '' );
+
+		$fields = isset( $assoc_args['fields'] )
+			? \array_map( 'trim', \explode( ',', (string) $assoc_args['fields'] ) )
+			: self::DEFAULT_FIELDS;
+
+		$formatter = new \WP_CLI\Formatter( $assoc_args, $fields );
+		$formatter->display_items( array( $this->module_to_row( $args[0], $module ) ) );
+	}
+
+	/**
+	 * Activates one or more modules.
+	 *
+	 * Reports per-key. Exits non-zero if any key failed.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <key>...
+	 * : One or more module keys to activate.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp atlantis module activate messages
+	 *     $ wp atlantis module activate messages autoupdates
+	 *
+	 * @param array<int, string>         $args       Positional args: one or more <key>.
+	 * @param array<string, string|bool> $assoc_args Flags (unused).
+	 */
+	public function activate( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$this->bulk_set_enabled( $args, true );
+	}
+
+	/**
+	 * Deactivates one or more modules.
+	 *
+	 * Reports per-key. Exits non-zero if any key failed. Mandatory modules
+	 * cannot be deactivated.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <key>...
+	 * : One or more module keys to deactivate.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp atlantis module deactivate tracking
+	 *
+	 * @param array<int, string>         $args       Positional args: one or more <key>.
+	 * @param array<string, string|bool> $assoc_args Flags (unused).
+	 */
+	public function deactivate( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$this->bulk_set_enabled( $args, false );
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Applies enable/disable to every key in $keys and reports per-key.
+	 *
+	 * @param array<int, string> $keys    Module keys.
+	 * @param bool               $enabled Target state.
+	 */
+	private function bulk_set_enabled( array $keys, bool $enabled ): void {
+		if ( 0 === \count( $keys ) ) {
+			\WP_CLI::error( 'At least one module key is required.' );
+		}
+
+		$modules   = $this->get_modules();
+		$verb_past = $enabled ? 'activated' : 'deactivated';
+		$verb_ing  = $enabled ? 'active' : 'inactive';
+		$failures  = 0;
+
+		foreach ( $keys as $key ) {
+			if ( ! isset( $modules[ $key ] ) ) {
+				\WP_CLI::warning( \sprintf( "Unknown module '%s'. Available: %s.", $key, \implode( ', ', \array_keys( $modules ) ) ) );
+				++$failures;
+				continue;
+			}
+
+			$module = $modules[ $key ];
+			if ( $module->is_active() === $enabled ) {
+				\WP_CLI::log( \sprintf( "Module '%s' is already %s.", $key, $verb_ing ) );
+				continue;
+			}
+
+			$result = $module->set_enabled( $enabled );
+			if ( \is_wp_error( $result ) ) {
+				\WP_CLI::warning( \sprintf( "Module '%s': %s", $key, $result->get_error_message() ) );
+				++$failures;
+				continue;
+			}
+
+			\WP_CLI::success( \sprintf( "Module '%s' %s.", $key, $verb_past ) );
+
+			$environment = $module->is_disabled();
+			if ( $enabled && \is_wp_error( $environment ) ) {
+				\WP_CLI::warning( \sprintf( "Module '%s' is environmentally disabled and will stay dormant: %s", $key, $environment->get_error_message() ) );
+			}
+		}
+
+		if ( 0 < $failures ) {
+			\WP_CLI::halt( 1 );
+		}
+	}
+
+	/**
+	 * Returns the modules registry, erroring out if Atlantis is not initialised.
+	 *
+	 * @return array<string, AbstractModule>
+	 */
+	private function get_modules(): array {
+		$plugin = Plugin::get_instance();
+		if ( ! isset( $plugin->modules ) ) {
+			\WP_CLI::error( 'Atlantis is not initialised on this site.' );
+		}
+
+		return $plugin->modules->modules;
+	}
+
+	/**
+	 * Resolves $key to a module or aborts with an error listing valid keys.
+	 *
+	 * @param string $key Module key.
+	 *
+	 * @return AbstractModule
+	 */
+	private function require_module( string $key ): AbstractModule {
+		$modules = $this->get_modules();
+		if ( '' === $key || ! isset( $modules[ $key ] ) ) {
+			\WP_CLI::error( \sprintf( "Unknown module '%s'. Available: %s.", $key, \implode( ', ', \array_keys( $modules ) ) ) );
+		}
+
+		return $modules[ $key ];
+	}
+
+	/**
+	 * Shapes a module into a row of scalar fields suitable for the Formatter.
+	 *
+	 * @param string         $key    Module key.
+	 * @param AbstractModule $module Module instance.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function module_to_row( string $key, AbstractModule $module ): array {
+		$environment = $module->is_disabled();
+
+		return array(
+			'key'         => $key,
+			'name'        => $module->get_name(),
+			'enabled'     => $module->is_active(),
+			'mandatory'   => $module->is_mandatory(),
+			'environment' => \is_wp_error( $environment ) ? $environment->get_error_message() : '',
+		);
+	}
+
+	// endregion
+}

--- a/src/CLI/Module_Command.php
+++ b/src/CLI/Module_Command.php
@@ -33,7 +33,7 @@ class Module_Command {
 	 *
 	 * @var array<int, string>
 	 */
-	private const DEFAULT_FIELDS = array( 'key', 'name', 'enabled', 'mandatory', 'environment' );
+	private const DEFAULT_FIELDS = array( 'key', 'status', 'environment' );
 
 	// region SUBCOMMANDS
 
@@ -45,7 +45,7 @@ class Module_Command {
 	 * [--fields=<fields>]
 	 * : Comma-separated list of fields to show.
 	 * ---
-	 * default: key,name,enabled,mandatory,environment
+	 * default: key,status,environment
 	 * ---
 	 *
 	 * [--format=<format>]
@@ -63,15 +63,15 @@ class Module_Command {
 	 * ## AVAILABLE FIELDS
 	 *
 	 * * key         - Module identifier used by activate/deactivate.
-	 * * name        - Human-readable module name.
-	 * * enabled     - Whether the module is currently active.
-	 * * mandatory   - Whether the module is mandatory (cannot be disabled).
+	 * * status      - "Active" or "Inactive".
+	 * * name        - Human-readable module name (opt-in).
+	 * * mandatory   - Whether the module is mandatory and cannot be disabled (opt-in).
 	 * * environment - Reason the module is blocked by environment, if any.
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp atlantis module list
-	 *     $ wp atlantis module list --fields=key,enabled --format=csv
+	 *     $ wp atlantis module list --fields=key,status --format=csv
 	 *
 	 * @subcommand list
 	 *
@@ -103,7 +103,7 @@ class Module_Command {
 	 * [--fields=<fields>]
 	 * : Comma-separated list of fields to show.
 	 * ---
-	 * default: key,name,enabled,mandatory,environment
+	 * default: key,status,environment
 	 * ---
 	 *
 	 * [--format=<format>]
@@ -276,8 +276,8 @@ class Module_Command {
 
 		return array(
 			'key'         => $key,
+			'status'      => $module->is_active() ? 'Active' : 'Inactive',
 			'name'        => $module->get_name(),
-			'enabled'     => $module->is_active(),
 			'mandatory'   => $module->is_mandatory(),
 			'environment' => \is_wp_error( $environment ) ? $environment->get_error_message() : '',
 		);

--- a/src/Modules/AbstractModule.php
+++ b/src/Modules/AbstractModule.php
@@ -82,8 +82,8 @@ abstract class AbstractModule {
 	 * toggled — the module just stays dormant at runtime, matching the admin
 	 * settings UI's behavior.
 	 *
-	 * @since   1.3.0
-	 * @version 1.3.0
+	 * @since   1.2.0
+	 * @version 1.2.0
 	 *
 	 * @param   bool $enabled Whether the module should be marked enabled.
 	 *

--- a/src/Modules/AbstractModule.php
+++ b/src/Modules/AbstractModule.php
@@ -75,6 +75,43 @@ abstract class AbstractModule {
 	}
 
 	/**
+	 * Persists the module's enabled flag while preserving any other sub-settings.
+	 *
+	 * Mandatory modules cannot be disabled. Environmentally-disabled modules
+	 * (`is_disabled()` returning a `WP_Error`) may still have their stored flag
+	 * toggled — the module just stays dormant at runtime, matching the admin
+	 * settings UI's behavior.
+	 *
+	 * @since   1.3.0
+	 * @version 1.3.0
+	 *
+	 * @param   bool $enabled Whether the module should be marked enabled.
+	 *
+	 * @return  true|\WP_Error True on success, WP_Error if the change is not allowed.
+	 */
+	public function set_enabled( bool $enabled ): true|\WP_Error {
+		if ( ! $enabled && $this->is_mandatory() ) {
+			return new \WP_Error(
+				'a8csp_atlantis_mandatory_module',
+				wp_sprintf(
+					/* translators: %s: module name */
+					__( 'The %s module is mandatory and cannot be disabled.', 'a8csp-atlantis' ),
+					$this->get_name()
+				)
+			);
+		}
+
+		$settings_key = a8csp_atlantis_generate_module_settings_key( $this->get_name() );
+		$settings     = a8csp_atlantis_get_module_settings( $this->get_name() );
+
+		$settings['enabled'] = $enabled ? '1' : '0';
+
+		update_option( $settings_key, $settings );
+
+		return true;
+	}
+
+	/**
 	 * Initializes the module if it is active.
 	 *
 	 * @since   1.0.0

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2,6 +2,8 @@
 
 namespace A8C\SpecialProjects\Atlantis;
 
+use A8C\SpecialProjects\Atlantis\CLI\Message_Command;
+use A8C\SpecialProjects\Atlantis\CLI\Module_Command;
 use A8C\SpecialProjects\Atlantis\REST\Status_Controller;
 
 defined( 'ABSPATH' ) || exit;
@@ -147,6 +149,11 @@ class Plugin {
 
 		$this->status_controller = new Status_Controller();
 		$this->status_controller->initialize();
+
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			\WP_CLI::add_command( 'atlantis module', Module_Command::class );
+			\WP_CLI::add_command( 'atlantis message', Message_Command::class );
+		}
 	}
 
 	// endregion

--- a/tests/Integration/ModuleEnableToggleCest.php
+++ b/tests/Integration/ModuleEnableToggleCest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Integration tests for AbstractModule::set_enabled().
+ */
+
+declare(strict_types=1);
+
+use A8C\SpecialProjects\Atlantis\Modules\Autoupdates\AutoUpdatePluginsFilter;
+use A8C\SpecialProjects\Atlantis\Modules\Messages\Messages;
+use PHPUnit\Framework\Assert;
+use Tests\Support\IntegrationTester;
+
+/**
+ * Tests for the shared module enable/disable writer that the WP-CLI commands
+ * (and any future REST endpoint) rely on.
+ */
+class ModuleEnableToggleCest {
+	/**
+	 * Toggling a non-mandatory module persists the new enabled flag.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function set_enabled_persists_the_enabled_flag( IntegrationTester $i ): void {
+		$module      = new AutoUpdatePluginsFilter();
+		$option_name = a8csp_atlantis_generate_module_settings_key( $module->get_name() );
+
+		$this->restore_option(
+			$option_name,
+			function () use ( $module, $option_name ): void {
+				update_option( $option_name, array( 'enabled' => '1' ) );
+
+				Assert::assertTrue( $module->set_enabled( false ) );
+				Assert::assertSame( '0', get_option( $option_name )['enabled'] );
+				Assert::assertFalse( $module->is_active() );
+
+				Assert::assertTrue( $module->set_enabled( true ) );
+				Assert::assertSame( '1', get_option( $option_name )['enabled'] );
+				Assert::assertTrue( $module->is_active() );
+			}
+		);
+	}
+
+	/**
+	 * Sub-settings stored alongside `enabled` must survive a toggle.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function set_enabled_preserves_sibling_subsettings( IntegrationTester $i ): void {
+		$module      = new AutoUpdatePluginsFilter();
+		$option_name = a8csp_atlantis_generate_module_settings_key( $module->get_name() );
+
+		$this->restore_option(
+			$option_name,
+			function () use ( $module, $option_name ): void {
+				update_option(
+					$option_name,
+					array(
+						'enabled'        => '1',
+						'rollout_window' => '48',
+						'time_window'    => 'weekend',
+					)
+				);
+
+				Assert::assertTrue( $module->set_enabled( false ) );
+
+				$stored = get_option( $option_name );
+				Assert::assertSame( '0', $stored['enabled'] );
+				Assert::assertSame( '48', $stored['rollout_window'] );
+				Assert::assertSame( 'weekend', $stored['time_window'] );
+			}
+		);
+	}
+
+	/**
+	 * Mandatory modules must refuse to be disabled and the stored flag must
+	 * stay unchanged.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function set_enabled_refuses_to_disable_mandatory_modules( IntegrationTester $i ): void {
+		$module      = new Messages();
+		$option_name = a8csp_atlantis_generate_module_settings_key( $module->get_name() );
+
+		$this->restore_option(
+			$option_name,
+			function () use ( $module, $option_name ): void {
+				update_option( $option_name, array( 'enabled' => '1' ) );
+
+				$result = $module->set_enabled( false );
+
+				Assert::assertInstanceOf( WP_Error::class, $result );
+				Assert::assertSame( 'a8csp_atlantis_mandatory_module', $result->get_error_code() );
+				Assert::assertSame( '1', get_option( $option_name )['enabled'] );
+				Assert::assertTrue( $module->is_active() );
+			}
+		);
+	}
+
+	/**
+	 * Mandatory modules may still be "set enabled" — it's a no-op success.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function set_enabled_true_on_mandatory_module_is_a_success( IntegrationTester $i ): void {
+		$module      = new Messages();
+		$option_name = a8csp_atlantis_generate_module_settings_key( $module->get_name() );
+
+		$this->restore_option(
+			$option_name,
+			function () use ( $module ): void {
+				Assert::assertTrue( $module->set_enabled( true ) );
+				Assert::assertTrue( $module->is_active() );
+			}
+		);
+	}
+
+	/**
+	 * Saves the option, runs the callback, and restores the original value.
+	 *
+	 * @param string   $option_name Option name to back up.
+	 * @param callable $callback    Callback to run while the option is mutated.
+	 *
+	 * @return void
+	 */
+	private function restore_option( string $option_name, callable $callback ): void {
+		$original = get_option( $option_name, null );
+		try {
+			$callback();
+		} finally {
+			if ( null === $original ) {
+				delete_option( $option_name );
+			} else {
+				update_option( $option_name, $original );
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds two WP-CLI command groups under `wp atlantis`:
  - `wp atlantis module list | status <key> | activate <key>... | deactivate <key>...`
  - `wp atlantis message list | get <id>` (wraps `Message_Query` / `Message`)
- Introduces `AbstractModule::set_enabled( bool ): true|WP_Error` as the canonical writer for the module enabled flag, used by the CLI today and ready for a future REST PATCH endpoint.

## Why

Operators currently have no scriptable, per-site way to toggle a module or inspect custom messages without going through the admin UI. PR #59 added a read-only fleet status endpoint; this PR adds the per-site CLI surface that fills out the rest of the day-to-day operational workflow.

## Design notes

- **Toggle rules live on the model.** `set_enabled()` refuses to disable mandatory modules and preserves any sibling sub-settings (e.g. Autoupdate Filter's rollout/time windows). The CLI command is a thin wrapper.
- **Environment-disabled modules** can still have their stored flag toggled — matches the admin UI's behavior of letting the checkbox value persist while the module stays dormant. The CLI prints a warning when activating a module that's blocked by environment.
- **Command naming** mirrors core WP-CLI conventions (`activate` / `deactivate`, multi-key positional args, standard `--format=` and `--fields=` flags via `WP_CLI\Formatter`).
- **Field allow-list** on `message list` / `message get` is validated before any dynamic property access on `Message`.
- **Registration is gated** behind `defined( 'WP_CLI' ) && WP_CLI` in `Plugin::initialize()` — zero cost outside CLI.

## Out of scope

- `message create / update / delete` — toggling and read access were the immediate ask; CRUD is a follow-up if needed.
- REST `PATCH /modules/<key>` — `set_enabled()` is now in place so this becomes a small follow-up PR.
- `--module=<key>` filter on the team51-cli `wpcom:atlantis-status` command (lives in a8cteam51/team51-cli, not here).

## Test plan

- [ ] On a wp-env instance with this branch active: `wp atlantis module list` shows all four modules with `enabled`, `mandatory`, and `environment` columns populated correctly.
- [ ] `wp atlantis module deactivate autoupdates` flips `is_active()` to false; rerun `list` confirms.
- [ ] `wp atlantis module activate autoupdates` flips it back; rerun `list` confirms.
- [ ] `wp atlantis module deactivate messages` returns an error (mandatory) and exits non-zero.
- [ ] `wp atlantis module activate messages autoupdates foo` reports success for the first two and an unknown-module error for `foo`; exits non-zero.
- [ ] `wp atlantis module status autoupdates --format=json` returns a single-row JSON document with the same fields.
- [ ] Seed at least one custom message via the admin UI, then run `wp atlantis message list` — row visible with id/title/type/status/created_at.
- [ ] `wp atlantis message list --type=warning --format=json` filters as expected.
- [ ] `wp atlantis message get <id> --fields=id,title,content` returns the decrypted content.
- [ ] `wp atlantis message get 99999` errors out cleanly.
- [ ] Run the integration suite: `npm run tests:run:integration` — new `ModuleEnableToggleCest` passes alongside the existing tests.
- [ ] After this branch is rebased on top of #59's merged trunk, verify `Plugin::initialize()` still registers both REST and CLI cleanly.

## Stacking

This branch is stacked on top of PR #59 (`add/modules-status-rest-endpoint`). Once #59 merges, this PR's base will retarget to `trunk` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)