### PR TITLE
Catch Throwable around maybe_initialize to survive plugin self-update race

### DIFF
--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -121,5 +121,19 @@ if ( is_wp_error( A8CSP_ATLANTIS_REQUIREMENTS ) ) {
 } else {
 	require_once A8CSP_ATLANTIS_DIR_PATH . '/functions.php';
 	register_activation_hook( __FILE__, 'a8csp_atlantis_maybe_disable_autoupdates_module_on_activation' );
-	add_action( 'plugins_loaded', array( a8csp_atlantis_get_plugin_instance(), 'maybe_initialize' ) );
+	add_action(
+		'plugins_loaded',
+		static function () {
+			// A plugin self-update temporarily removes files between clear_destination()
+			// and the move into place. A concurrent request can hit this window with
+			// Plugin.php still in OPcache but an autoload target missing on disk,
+			// producing a "Class not found" fatal. Swallow that one request rather
+			// than WSOD; the next request — post-update — will boot normally.
+			try {
+				a8csp_atlantis_get_plugin_instance()->maybe_initialize();
+			} catch ( \Throwable $t ) {
+				error_log( sprintf( '[a8csp-atlantis] maybe_initialize() failed: %s in %s:%d', $t->getMessage(), $t->getFile(), $t->getLine() ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			}
+		}
+	);
 }


### PR DESCRIPTION
## Summary

- Wrap the `plugins_loaded` callback in a `try { … } catch ( \Throwable $t )` so a transient autoload failure during a plugin self-update logs instead of WSODs the request.
- No behaviour change for normal requests; only requests caught inside the upgrade window are affected, and they are degraded from a fatal to a silent skip + error log entry.

## Why

Several production sites have logged a one-shot fatal:

```
PHP Fatal error: Uncaught Error: Class "A8C\SpecialProjects\Atlantis\Encryption" not found
in /srv/htdocs/wp-content/plugins/a8csp-atlantis/src/Plugin.php:127
```

The line numbers (`127` = `new Encryption()`, `156` = `$this->initialize()`) match pre-1.2.0 `Plugin.php`, so the affected sites are running an older release and being updated to 1.2.0. `Encryption.php` exists in those versions at the same path the autoloader maps to — the class can only be "not found" if the file is transiently missing on disk.

That happens during `Plugin_Upgrader::install_package()`:

1. Extract the new zip to a temp dir.
2. **`clear_destination()` recursively deletes the old plugin directory's contents.**
3. Move the new files into place.

A concurrent request (typically the WP-Cron loopback that triggered the update, or the user request that spawned the cron) can enter `plugins_loaded` between 2 and 3. `Plugin.php` is still in OPcache so `new Encryption()` runs from the old line numbers, but the autoloader's `require` of `src/Encryption.php` fails because the file was just deleted. Fatal.

Once the upgrade completes, files are coherent again and the site recovers — which is why the error appears exactly once per site, then never again.

This PR doesn't fix the underlying race (that's a WP core / `move_dir` concern) but makes the plugin resilient to it: the one request caught in the window logs and bails instead of fataling.

## Test plan

- [ ] Lint: `composer run lint:php` passes locally.
- [ ] Smoke: load any wp-admin page; plugin initializes normally (catch path is not hit).
- [ ] Simulated failure: temporarily rename `src/Encryption.php` to `.bak`, hit the site — expect a logged `[a8csp-atlantis] maybe_initialize() failed: …` line and no WSOD. Restore the file and reload — site boots normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin stability during concurrent updates to prevent fatal errors when dependencies are temporarily unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->