### PR TITLE
Bilmur: gate output with client-side host guard

### DIFF
--- a/src/Modules/Tracking/Integrations/Bilmur.php
+++ b/src/Modules/Tracking/Integrations/Bilmur.php
@@ -59,7 +59,9 @@ class Bilmur extends AbstractIntegration {
 		// Always register the wpcomsh filter for Atomic compatibility (harmless on non-Atomic sites).
 		add_filter( 'wpcomsh_rum_kv', array( self::class, 'filter_wpcomsh_rum_kv' ), 10, 2 );
 
-		if ( ! self::is_wpcomsh_bilmur_active() ) {
+		if ( self::is_wpcomsh_bilmur_active() ) {
+			$this->register_atomic_host_guard();
+		} else {
 			$this->initialize_bilmur_output();
 		}
 	}
@@ -101,13 +103,26 @@ class Bilmur extends AbstractIntegration {
 	/**
 	 * Initialize Bilmur script and meta tag output for non-wpcomsh sites.
 	 *
+	 * The meta and script are not emitted statically. Instead, a small inline
+	 * guard injects both at runtime, but only when the visitor's hostname matches
+	 * the canonical site host. Scraped/copied sites therefore never load bilmur
+	 * and never report to Grafana.
+	 *
 	 * @since   1.2.0
-	 * @version 1.2.0
+	 * @version 1.3.0
 	 */
 	private function initialize_bilmur_output(): void {
 		add_action(
-			'wp_enqueue_scripts',
+			'wp_footer',
 			static function () {
+				$expected_host = (string) wp_parse_url( (string) home_url(), PHP_URL_HOST );
+				if ( '' === $expected_host ) {
+					return;
+				}
+
+				$custom_properties               = defined( 'WPCOMSP_BILMUR_CUSTOM_PROPERTIES' ) && is_array( WPCOMSP_BILMUR_CUSTOM_PROPERTIES ) ? WPCOMSP_BILMUR_CUSTOM_PROPERTIES : array();
+				$custom_properties['woo_active'] = class_exists( 'WooCommerce' ) ? '1' : '0';
+
 				// Request a new version of bilmur every week.
 				// This keeps bilmur up-to-date independently of CDN caching times.
 				$weekly_cachebust = 'm=' . gmdate( 'YW' );
@@ -116,55 +131,80 @@ class Bilmur extends AbstractIntegration {
 				// Just increment this number if that's the case.
 				$manual_version = '1';
 
-				wp_enqueue_script(
-					'bilmur',
-					'https://s0.wp.com/wp-content/js/bilmur.min.js?' . $weekly_cachebust,
-					array(),
-					$manual_version,
-					array(
-						'strategy'  => 'defer',
-						'in_footer' => true,
-					)
+				$config = array(
+					'host'        => $expected_host,
+					'provider'    => (string) WPCOMSP_BILMUR_PROVIDER,
+					'service'     => (string) WPCOMSP_BILMUR_SERVICE,
+					'customProps' => (string) wp_json_encode( $custom_properties ),
+					'siteTz'      => self::get_timezone_string(),
+					'src'         => 'https://s0.wp.com/wp-content/js/bilmur.min.js?' . $weekly_cachebust . '&ver=' . $manual_version,
 				);
+				?>
+				<script id="bilmur-host-guard" nowprocket>
+				(function () {
+					var cfg = <?php echo wp_json_encode( $config ); ?>;
+					if ( window.location.hostname !== cfg.host ) {
+						return;
+					}
+					var meta = document.createElement( 'meta' );
+					meta.id = 'bilmur';
+					meta.setAttribute( 'property', 'bilmur:data' );
+					meta.setAttribute( 'content', '' );
+					meta.setAttribute( 'data-provider', cfg.provider );
+					meta.setAttribute( 'data-service', cfg.service );
+					meta.setAttribute( 'data-custom-props', cfg.customProps );
+					meta.setAttribute( 'data-site-tz', cfg.siteTz );
+					( document.head || document.documentElement ).appendChild( meta );
+
+					var s = document.createElement( 'script' );
+					s.id = 'bilmur-js';
+					s.src = cfg.src;
+					s.defer = true;
+					document.body.appendChild( s );
+				})();
+				</script>
+				<?php
 			}
 		);
+	}
 
-		// WP Rocket compatibility: prevent "Delay JavaScript Execution" from
-		// blocking the bilmur beacon. The `nowprocket` attribute tells WP Rocket
-		// to skip delaying this script.
-		$active_plugins = get_option( 'active_plugins' );
-		if ( is_array( $active_plugins ) && in_array( 'wp-rocket/wp-rocket.php', $active_plugins, true ) ) {
-			add_filter(
-				'wp_script_attributes',
-				static function ( array $attributes ): array {
-					if ( isset( $attributes['id'] ) && 'bilmur-js' === $attributes['id'] ) {
-						$attributes['nowprocket'] = true;
-					}
-					return $attributes;
-				}
-			);
-		}
-
-		// Output bilmur config as a <meta> tag for the script to pick up.
+	/**
+	 * Register a client-side host guard for Atomic sites where wpcomsh emits the
+	 * bilmur tags directly. Since wpcomsh's output can't be suppressed from here,
+	 * the guard removes the meta tag (and best-effort the script element) when
+	 * the visitor's hostname doesn't match the canonical site host. Without the
+	 * meta tag, bilmur has no provider/service to report to.
+	 *
+	 * @since   1.3.0
+	 * @version 1.3.0
+	 */
+	private function register_atomic_host_guard(): void {
 		add_action(
 			'wp_footer',
 			static function () {
-				$custom_properties = defined( 'WPCOMSP_BILMUR_CUSTOM_PROPERTIES' ) && is_array( WPCOMSP_BILMUR_CUSTOM_PROPERTIES ) ? WPCOMSP_BILMUR_CUSTOM_PROPERTIES : array();
-
-				$custom_properties['woo_active'] = class_exists( 'WooCommerce' ) ? '1' : '0';
-
+				$expected_host = (string) wp_parse_url( (string) home_url(), PHP_URL_HOST );
+				if ( '' === $expected_host ) {
+					return;
+				}
 				?>
-				<meta
-					id="bilmur"
-					property="bilmur:data"
-					content=""
-					data-provider="<?php echo esc_attr( WPCOMSP_BILMUR_PROVIDER ); ?>"
-					data-service="<?php echo esc_attr( WPCOMSP_BILMUR_SERVICE ); ?>"
-					data-custom-props="<?php echo esc_attr( (string) wp_json_encode( $custom_properties ) ); ?>"
-					data-site-tz="<?php echo esc_attr( self::get_timezone_string() ); ?>"
-				>
+				<script id="bilmur-host-guard" nowprocket>
+				(function () {
+					if ( window.location.hostname === <?php echo wp_json_encode( $expected_host ); ?> ) {
+						return;
+					}
+					var meta = document.getElementById( 'bilmur' );
+					if ( meta && meta.parentNode ) {
+						meta.parentNode.removeChild( meta );
+					}
+					var script = document.getElementById( 'bilmur-js' );
+					if ( script && script.parentNode ) {
+						script.parentNode.removeChild( script );
+					}
+				})();
+				</script>
 				<?php
-			}
+			},
+			PHP_INT_MAX
 		);
 	}
 


### PR DESCRIPTION
## Summary

- Scraped/copied sites have been retaining the bilmur `<script>` and `<meta>` tags from the source HTML and reporting bogus traffic to Grafana under the canonical site's custom properties (`wpcomsp=1`, etc.). Server-side filtering can't help because the scraped HTML is served from a server we don't control, so the defense has to run in the visitor's browser.
- **Pressable / non-wpcomsh path:** the script and meta tag are no longer emitted statically. An inline guard at `wp_footer` injects both at runtime, but only when `window.location.hostname` matches `home_url()`'s host. Scraped HTML has zero bilmur footprint.
- **Atomic / wpcomsh path:** wpcomsh still emits its tags (we can't suppress that from here). A late-priority (`PHP_INT_MAX`) inline guard removes `<meta id="bilmur">` on hostname mismatch; without the meta, bilmur has no provider/service to report to.
- The previous `wp_script_attributes` filter that added `nowprocket` to the static `bilmur-js` tag is removed (there is no static tag anymore). Both inline guards carry `nowprocket` to opt out of WP Rocket's Delay JS.

## Test plan

- [ ] On a production Pressable site with `WPCOMSP_BILMUR_*` configured: confirm `<script id="bilmur-js">` is injected into the DOM after page load and a bilmur beacon fires.
- [ ] Save that page to disk (or serve it from a different host) and load it in a browser — confirm no `bilmur-js` script appears and no beacon fires.
- [ ] On an Atomic site (wpcomsh handling bilmur): confirm the canonical host still loads bilmur and reports the `wpcomsp=1` custom prop via `wpcomsh_rum_kv`.
- [ ] Mirror that Atomic page to a different hostname and load it — confirm `<meta id="bilmur">` is removed and no beacon is sent (or at minimum no provider/service is reported).
- [ ] Verify the guard inline script is not delayed by WP Rocket's Delay JS feature on sites that have it enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Bilmur tracking hostname validation for multi-host and Atomic site configurations.
  * Improved tracking initialization reliability across different site types.

* **Refactor**
  * Optimized Bilmur integration with streamlined runtime script loading and configuration initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->