### PR TITLE
Keep the Autoupdates module off front-end page loads

### DIFF
--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -3,7 +3,7 @@
  * The A8CSP Atlantis bootstrap file.
  *
  * @since       1.0.0
- * @version     1.2.0
+ * @version     1.2.1
  * @package     A8C\SpecialProjects\Plugins
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
@@ -15,7 +15,7 @@
  * Plugin URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Update URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Description:             Centralized site management for Team51.
- * Version:                 1.2.0
+ * Version:                 1.2.1
  * Requires at least:       6.8
  * Tested up to:            7.0
  * Requires PHP:            8.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a8csp-atlantis",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A scaffold for A8C Special Projects plugins",
   "author": {
     "name": "A8C Special Projects Team",

--- a/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
+++ b/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
@@ -128,41 +128,46 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 		$settings      = get_transient( $transient_key );
 
 		if ( empty( $settings ) ) {
-			$response = wp_safe_remote_get(
-				'https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/autoupdate-plugin/v1/settings/',
-				array( 'headers' => array( 'Accept' => 'application/json' ) )
-			);
-
-			if ( is_wp_error( $response ) ) {
-				throw new \RuntimeException( wp_kses_post( $response->get_error_message() ) );
-			}
-
-			$response_code = wp_remote_retrieve_response_code( $response );
-			$response_body = wp_remote_retrieve_body( $response );
-
-			// Check that the response code is a 2xx code.
-			if ( ! \str_starts_with( (string) $response_code, '2' ) ) {
-				$response_message = wp_remote_retrieve_response_message( $response );
-				throw new \RuntimeException( wp_kses_post( $response_message ), absint( $response_code ) );
-			}
-
 			try {
+				$response = wp_safe_remote_get(
+					'https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/autoupdate-plugin/v1/settings/',
+					array(
+						'timeout' => 2,
+						'headers' => array( 'Accept' => 'application/json' ),
+					)
+				);
+
+				if ( is_wp_error( $response ) ) {
+					throw new \RuntimeException( wp_kses_post( $response->get_error_message() ) );
+				}
+
+				$response_code = wp_remote_retrieve_response_code( $response );
+				$response_body = wp_remote_retrieve_body( $response );
+
+				// Check that the response code is a 2xx code.
+				if ( ! \str_starts_with( (string) $response_code, '2' ) ) {
+					$response_message = wp_remote_retrieve_response_message( $response );
+					throw new \RuntimeException( wp_kses_post( $response_message ), absint( $response_code ) );
+				}
+
 				$decoded_body = json_decode( $response_body, false, 512, JSON_THROW_ON_ERROR );
-			} catch ( \JsonException $exception ) {
+
+				// if the settings are empty, we still need to return an object
+				if ( ! is_object( $decoded_body ) ) {
+					$object              = new \stdClass();
+					$object->placeholder = $decoded_body;
+					$decoded_body        = $object;
+				}
+
+				// Save the settings in a transient for 5 minutes
+				set_transient( $transient_key, $decoded_body, 5 * MINUTE_IN_SECONDS );
+
+				$settings = $decoded_body;
+			} catch ( \Exception $exception ) {
+				// Negative-cache the fail-safe so a slow/down OpsOasis cannot block every uncached page load.
+				set_transient( $transient_key, (object) array( 'disable_all' => true ), 5 * MINUTE_IN_SECONDS );
 				throw $exception;
 			}
-
-			// if the settings are empty, we still need to return an object
-			if ( ! is_object( $decoded_body ) ) {
-				$object              = new \stdClass();
-				$object->placeholder = $decoded_body;
-				$decoded_body        = $object;
-			}
-
-			// Save the settings in a transient for 5 minutes
-			set_transient( $transient_key, $decoded_body, 5 * MINUTE_IN_SECONDS );
-
-			$settings = $decoded_body;
 		}
 
 		return $settings;

--- a/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
+++ b/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
@@ -58,6 +58,11 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 	 * @version 1.0.0
 	 */
 	protected function initialize(): void {
+		// Autoupdate hooks only fire in admin or during cron/CLI update runs — skip front-end requests entirely.
+		if ( ! $this->is_autoupdate_context() ) {
+			return;
+		}
+
 		// get the centralized settings from opsoasis
 		try {
 			$this->settings = $this->get_auto_update_settings();
@@ -112,6 +117,15 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 	}
 
 	// endregion
+
+	/**
+	 * Whether WordPress evaluates auto-update decisions in the current request (admin, WP-Cron, or WP-CLI).
+	 *
+	 * @return  bool
+	 */
+	private function is_autoupdate_context(): bool {
+		return is_admin() || wp_doing_cron() || ( defined( 'WP_CLI' ) && WP_CLI );
+	}
 
 	/**
 	 * Load settings from the centralized settings page

--- a/tests/Integration/AutoupdatesTestCest.php
+++ b/tests/Integration/AutoupdatesTestCest.php
@@ -214,6 +214,77 @@ class AutoupdatesTestCest {
 	}
 
 	/**
+	 * A failed OpsOasis fetch negative-caches the fail-safe default instead of refetching on every request.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function failed_settings_fetch_negative_caches_safe_default( IntegrationTester $i ): void {
+		delete_transient( 'wpcpmsp_auto_update_settings' );
+
+		$force_failure = static function () {
+			return new WP_Error( 'http_request_failed', 'Simulated OpsOasis outage' );
+		};
+		add_filter( 'pre_http_request', $force_failure, 10, 3 );
+
+		try {
+			$module = new AutoUpdatePluginsFilter();
+			$method = new ReflectionMethod( $module, 'get_auto_update_settings' );
+			$method->setAccessible( true );
+
+			$threw = false;
+			try {
+				$method->invoke( $module );
+			} catch ( \Exception $exception ) {
+				$threw = true;
+			}
+
+			Assert::assertTrue( $threw, 'A failed remote fetch should surface an exception to the caller.' );
+
+			$cached = get_transient( 'wpcpmsp_auto_update_settings' );
+			Assert::assertIsObject( $cached );
+			Assert::assertTrue( ! empty( $cached->disable_all ) );
+		} finally {
+			remove_filter( 'pre_http_request', $force_failure, 10 );
+			delete_transient( 'wpcpmsp_auto_update_settings' );
+		}
+	}
+
+	/**
+	 * A warm settings transient is returned without making a remote request.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function warm_settings_transient_skips_remote_request( IntegrationTester $i ): void {
+		set_transient( 'wpcpmsp_auto_update_settings', (object) array( 'disable_all' => true ), 5 * MINUTE_IN_SECONDS );
+
+		$http_calls = 0;
+		$count_http = static function ( $pre ) use ( &$http_calls ) {
+			++$http_calls;
+			return new WP_Error( 'unexpected_http', 'No remote request should be made when the transient is warm.' );
+		};
+		add_filter( 'pre_http_request', $count_http, 10, 3 );
+
+		try {
+			$module = new AutoUpdatePluginsFilter();
+			$method = new ReflectionMethod( $module, 'get_auto_update_settings' );
+			$method->setAccessible( true );
+
+			$settings = $method->invoke( $module );
+
+			Assert::assertIsObject( $settings );
+			Assert::assertTrue( ! empty( $settings->disable_all ) );
+			Assert::assertSame( 0, $http_calls, 'A warm transient must not trigger a remote request.' );
+		} finally {
+			remove_filter( 'pre_http_request', $count_http, 10 );
+			delete_transient( 'wpcpmsp_auto_update_settings' );
+		}
+	}
+
+	/**
 	 * Set current user as admin to satisfy capability checks.
 	 *
 	 * @return void

--- a/tests/Integration/AutoupdatesTestCest.php
+++ b/tests/Integration/AutoupdatesTestCest.php
@@ -285,6 +285,65 @@ class AutoupdatesTestCest {
 	}
 
 	/**
+	 * Auto-update context gating returns false on a front-end request and true during cron.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function autoupdate_context_gating_distinguishes_request_types( IntegrationTester $i ): void {
+		$module = new AutoUpdatePluginsFilter();
+		$method = new ReflectionMethod( $module, 'is_autoupdate_context' );
+		$method->setAccessible( true );
+
+		// Front-end request: none of the three contexts apply.
+		Assert::assertFalse( is_admin(), 'Test precondition: not an admin request.' );
+		Assert::assertFalse( wp_doing_cron(), 'Test precondition: not a cron request.' );
+		Assert::assertFalse( defined( 'WP_CLI' ) && WP_CLI, 'Test precondition: not a WP-CLI request.' );
+		Assert::assertFalse( $method->invoke( $module ), 'A front-end request is not an autoupdate context.' );
+
+		// Cron request: wp_doing_cron() is filterable, so simulate it without loading admin includes.
+		add_filter( 'wp_doing_cron', '__return_true' );
+		try {
+			Assert::assertTrue( $method->invoke( $module ), 'A cron request is an autoupdate context.' );
+		} finally {
+			remove_filter( 'wp_doing_cron', '__return_true' );
+		}
+	}
+
+	/**
+	 * On a front-end request, initialize() short-circuits before fetching OpsOasis settings.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function front_end_initialize_makes_no_remote_request( IntegrationTester $i ): void {
+		Assert::assertFalse( is_admin(), 'Test precondition: not an admin request.' );
+		delete_transient( 'wpcpmsp_auto_update_settings' );
+
+		$http_calls = 0;
+		$count_http = static function ( $pre ) use ( &$http_calls ) {
+			++$http_calls;
+			return new WP_Error( 'unexpected_http', 'initialize() must not call OpsOasis on a front-end request.' );
+		};
+		add_filter( 'pre_http_request', $count_http, 10, 3 );
+
+		try {
+			$module = new AutoUpdatePluginsFilter();
+			$method = new ReflectionMethod( $module, 'initialize' );
+			$method->setAccessible( true );
+			$method->invoke( $module );
+
+			Assert::assertSame( 0, $http_calls, 'No remote request should be made on a front-end request.' );
+			Assert::assertFalse( get_transient( 'wpcpmsp_auto_update_settings' ), 'No settings transient should be written on a front-end request.' );
+		} finally {
+			remove_filter( 'pre_http_request', $count_http, 10 );
+			delete_transient( 'wpcpmsp_auto_update_settings' );
+		}
+	}
+
+	/**
 	 * Set current user as admin to satisfy capability checks.
 	 *
 	 * @return void


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Autoupdates module fetched centralized settings from OpsOasis with a synchronous `wp_safe_remote_get` during `plugins_loaded` — on **every** front-end request, with no admin/cron gate. This PR keeps that work off the front end, two ways:

* **Gate the module to the contexts that use it.** `initialize()` now early-returns on non-admin / non-cron / non-CLI requests via `is_autoupdate_context()` = `is_admin() || wp_doing_cron() || ( defined( 'WP_CLI' ) && WP_CLI )`. Every hook the module registers — the `auto_update_{plugin,core,theme}` filters, the update-email filters, `plugin_auto_update_setting_html`, `admin_init`/`admin_notices`, `upgrader_process_complete` — only ever fires in admin, WP-Cron, or WP-CLI, so a logged-out page view was doing the OpsOasis fetch and registering ~18 hooks for nothing.
* REST requests are intentionally **not** treated as an autoupdate context: core's plugin/theme REST controllers don't run an upgrader (`WP_REST_Plugins_Controller::update_item()` only toggles activation; themes REST is read-only) and the auto-update Site Health test is a "direct" (non-REST) test — so no autoupdate hook fires during a REST request, and treating REST as one would just re-introduce the blocking fetch.
* **Harden the fetch for the admin/cron path that remains.** `get_auto_update_settings()` now negative-caches the fail-safe `{ disable_all: true }` object for 5 minutes on **any** fetch failure (network error, non-2xx, JSON decode) before re-throwing — previously every failure threw *before* `set_transient`, so a slow/unreachable OpsOasis caused a blocking request on every cache-cold request. Also adds an explicit `'timeout' => 2`, and drops a now-redundant inner `try/catch (\JsonException)` (handled by the new outer catch). Mirrors the negative-cache-on-failure pattern already used for the GitHub release check in `a8csp-atlantis.php`.
* No change to the autoupdate decision itself: `disable_all = true` on failure is the existing fail-safe. One nuance: the red "Unable to get autoupdate settings (…)" admin notice now shows only on the **first** failing request within each 5-minute window (anti-flapping); during the window admins see the generic "all autoupdates deactivated" notice instead.
* Added integration tests for the gate and the fetch hardening; bumped the plugin version 1.2.0 → 1.2.1.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* [ ] CI codeception suite green (PHP 8.2/8.3/8.4), including the four new `AutoupdatesTestCest` tests: `autoupdate_context_gating_distinguishes_request_types`, `front_end_initialize_makes_no_remote_request`, `failed_settings_fetch_negative_caches_safe_default`, `warm_settings_transient_skips_remote_request`.
* [ ] Gate: load a logged-out front-end page → no request to OpsOasis is made and no `wpcpmsp_auto_update_settings` transient is written; an admin page / cron run still fetches and applies settings as before.
* [ ] Hardening repro (before): point the OpsOasis URL at an unreachable/slow host, hit a context that fetches (admin/cron) cold → request blocks ~5s and repeats. After: first request bounded to ≤2s, transient set to `{ disable_all: true }`, subsequent requests return immediately for 5 minutes.
* [ ] `composer run-script packages-install && composer run lint:php` passes locally (phpcs/phpmd/phpstan; phpstan already excludes this file) — vendor/ wasn't installed in the working copy used to author this.

Mentions #
