### PR TITLE
fix: disable img sizes=auto to mitigate Gutenberg bug (1.2.2)

### DIFF
--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -3,7 +3,7 @@
  * The A8CSP Atlantis bootstrap file.
  *
  * @since       1.0.0
- * @version     1.2.1
+ * @version     1.2.2
  * @package     A8C\SpecialProjects\Plugins
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
@@ -15,7 +15,7 @@
  * Plugin URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Update URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Description:             Centralized site management for Team51.
- * Version:                 1.2.1
+ * Version:                 1.2.2
  * Requires at least:       6.8
  * Tested up to:            7.0
  * Requires PHP:            8.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a8csp-atlantis",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A scaffold for A8C Special Projects plugins",
   "author": {
     "name": "A8C Special Projects Team",

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -138,6 +138,8 @@ class Plugin {
 	 * @return  void
 	 */
 	protected function initialize(): void {
+		$this->register_core_compat_filters();
+
 		$this->encryption = new Encryption();
 		$this->encryption->initialize();
 
@@ -154,6 +156,26 @@ class Plugin {
 			\WP_CLI::add_command( 'atlantis module', Module_Command::class );
 			\WP_CLI::add_command( 'atlantis message', Message_Command::class );
 		}
+	}
+
+	/**
+	 * Registers temporary WordPress-core compatibility filters.
+	 *
+	 * These mitigations run on every active install, independent of module
+	 * settings, so they can be rolled out fleet-wide quickly. Remove each
+	 * filter once the corresponding upstream fix has shipped.
+	 *
+	 * @since   1.2.2
+	 * @version 1.2.2
+	 *
+	 * @return  void
+	 */
+	private function register_core_compat_filters(): void {
+		// Disable the `sizes="auto"` attribute WordPress 6.7+ adds to lazy-loaded
+		// images. Mitigates a Gutenberg bug affecting partner sites until the
+		// upstream fix is released. Remove once that ships.
+		// See: https://github.com/WordPress/gutenberg/pull/80386
+		add_filter( 'wp_img_tag_add_auto_sizes', '__return_false' );
 	}
 
 	// endregion


### PR DESCRIPTION
## Summary

Emergency mitigation. WordPress 6.7+ automatically adds a `sizes="auto"` attribute to lazy-loaded images via the `wp_img_tag_add_auto_sizes` filter. A Gutenberg bug in this behavior is affecting potentially **hundreds of partner sites**, and the upstream fix — [WordPress/gutenberg#80386](https://github.com/WordPress/gutenberg/pull/80386) — has no confirmed release date.

This PR disables the auto-`sizes` behavior fleet-wide so we don't have to wait on a Gutenberg release:

```php
add_filter( 'wp_img_tag_add_auto_sizes', '__return_false' );
```

## Where it lives / why

Registered in `Plugin::initialize()` (a new `register_core_compat_filters()` helper) rather than behind a module, so it runs on **every active install regardless of module settings** — enabling the fastest possible blanket rollout. The helper is clearly marked temporary and links the Gutenberg PR so it's easy to find and remove once the upstream fix ships.

## Safety

- `add_filter()` + `__return_false` are both WordPress core — no version/dependency risk.
- The filter only fires during image-tag rendering; harmless where the attribute wasn't being added.
- No error/notice if the hook is absent — registration is inert until the filter runs.

## Version

Patch bump **1.2.1 → 1.2.2** (`a8csp-atlantis.php` header + `@version`, `package.json`), per the release checklist in `README.md`.

## Follow-up

Revert `register_core_compat_filters()` (or just the single line) once the Gutenberg fix is released and has propagated to sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)