### PR TITLE
fix: survive mid-update autoload races instead of fataling the site (1.2.3)

### DIFF
--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -3,7 +3,7 @@
  * The A8CSP Atlantis bootstrap file.
  *
  * @since       1.0.0
- * @version     1.2.2
+ * @version     1.2.3
  * @package     A8C\SpecialProjects\Plugins
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
@@ -15,7 +15,7 @@
  * Plugin URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Update URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Description:             Centralized site management for Team51.
- * Version:                 1.2.2
+ * Version:                 1.2.3
  * Requires at least:       6.8
  * Tested up to:            7.0
  * Requires PHP:            8.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a8csp-atlantis",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A scaffold for A8C Special Projects plugins",
   "author": {
     "name": "A8C Special Projects Team",

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -186,7 +186,7 @@ class Plugin {
 	 * Initializes the plugin components if all prerequisites are met.
 	 *
 	 * @since   1.0.0
-	 * @version 1.0.0
+	 * @version 1.2.3
 	 *
 	 * @return  void
 	 */
@@ -197,7 +197,16 @@ class Plugin {
 			return;
 		}
 
-		$this->initialize();
+		try {
+			$this->initialize();
+		} catch ( \Throwable $e ) {
+			// A plugin/core update replaces files one at a time, so the autoloader
+			// can briefly fail to resolve a class mid-copy (or against stale
+			// opcache right after). Skip init for this request rather than taking
+			// down the whole site; the next request initializes normally once the
+			// files have settled.
+			error_log( 'A8CSP Atlantis: initialization skipped this request — ' . $e->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		}
 	}
 
 	// endregion


### PR DESCRIPTION
## Problem

Some sites intermittently fatal during plugin/core updates with:

```
PHP Fatal error: Uncaught Error: Class "A8C\SpecialProjects\Atlantis\Encryption" not found in .../src/Plugin.php:141
Stack trace:
#0 .../src/Plugin.php(178): ...->initialize()
#1 .../wp-includes/class-wp-hook.php(341): ...->maybe_initialize('')
...
#4 .../wp-settings.php(622): do_action('plugins_loaded')
```

This is **not** a logic bug — `Encryption` exists and the autoloader (PSR-4 + optimized classmap, non-authoritative) resolves it correctly under normal conditions.

## Root cause

WordPress updates a plugin with `copy_dir()`, which replaces files **one at a time** — not an atomic directory swap. A request that lands in that window (or hits stale opcache immediately after — common on Atomic/WoA where `opcache.validate_timestamps=0`) can have the autoloader resolve a class to a file that is momentarily **absent or half-written**, producing a `Class not found` `Error`.

Because it's thrown from inside `do_action('plugins_loaded')`, the uncaught error takes down the **entire site**, not just Atlantis. It's:
- **intermittent** — only requests inside the narrow copy window trip it;
- **update-correlated** — matches the reported "some installations/updates";
- **always `Encryption`** — it's simply the *first* class instantiated in `initialize()`; any later missing file would fatal instead.

No autoloader configuration fixes a file that isn't on disk yet — the only levers are deploy atomicity (platform-controlled) or making our bootstrap resilient.

## Fix

Wrap `initialize()` in `try/catch( \Throwable )` so a transient resolution failure degrades to **"Atlantis skips this one request" (logged)** instead of a site-wide 500. The next request initializes normally once files have settled.

```php
try {
    $this->initialize();
} catch ( \Throwable $e ) {
    error_log( 'A8CSP Atlantis: initialization skipped this request — ' . $e->getMessage() );
}
```

**Tradeoff (intentional):** catching `\Throwable` also means a *genuine* fatal in module code would make the plugin silently not load rather than white-screen every page. For an operational plugin, "log and degrade" is the right call over "kill the site" — hence the `error_log()` so it stays diagnosable.

## Scope / caveats

- Protects **all future updates** from this failure mode.
- Does **not** fully protect the update that *installs* it (the running bootstrap during that copy may still be the old, unguarded code).
- Complementary, platform-side: ensure **opcache is invalidated on deploy** and consider **staggering** large rollouts.

## Version

Patch bump **1.2.2 → 1.2.3** (`a8csp-atlantis.php` header + `@version`, `package.json`), per the `README.md` release checklist.

## Verification

- `phpcs` — clean on both changed files.
- `phpstan` — no errors on `Plugin.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)