### PR TITLE
feat: fleet snippet runner (signed remediation deploys, no release)

### DIFF
--- a/docs/snippet-runner-design.md
+++ b/docs/snippet-runner-design.md
@@ -1,0 +1,414 @@
+# Design: Atlantis Fleet Snippet Runner
+
+**Status:** Draft for review
+**Author:** Nick P and Claude Code
+**Date:** 2026-07-18
+**Repos touched:** `a8csp-atlantis`, `opsoasis`, `team51-cli`
+
+---
+
+## 1. Motivation
+
+When a core/plugin regression breaks something across our fleet coupled with a delayed fix rollout, one of our only remediations today is: write a fix into Atlantis → cut a release → force-update the plugin on hundreds of sites via the WPCOM dashboard (tedious) or the new `jetpack:plugin-update` batch command (better, but still in development and still needs a full release cycle).
+
+We want to deploy a **small unit of remediation code** to every Team 51 site running Atlantis *without* cutting an Atlantis release and *without* SSH-iterating sites — add it in one place, have it land on the whole fleet.
+
+Two prior workstreams establish the pattern we build on:
+
+- **opsoasis#390** — `POST wpcomsp/wpcom/v1/sites/batch/plugin-update`: a central endpoint that fans out concurrently (Amphp) to per-site WPCOM v1.2 REST calls using the shared **blog/partner token**.
+- **team51-cli#138** — `jetpack:plugin-update <slug>`: thin CLI that collects a site-id list and delegates one batch call to that endpoint.
+
+This design is the **write-side twin** of the existing read-side
+`sites/batch/atlantis-status` → `a8csp-atlantis/v1/status` pattern.
+
+---
+
+## 2. Goals / Non-Goals
+
+### Goals
+- Deploy an **arbitrary PHP snippet** (a small mu-plugin-shaped unit of code) to all managed Team 51 sites, on demand, in minutes — no Atlantis release required.
+- Snippet content is **only ever delivered to sites OpsOasis already manages** — never exposed to random public installs of the (public) Atlantis repo.
+- Snippet is **cryptographically signed**; a site refuses to run anything it can't verify.
+- A bad snippet **cannot fatal a site** — it fails closed, and there's a fleet-wide kill switch.
+- Full lifecycle (deploy / observe / reconcile / remove) lives in existing Team 51 tooling: OpsOasis batch endpoints, the CLI, and Atlantis wp-cli commands.
+
+### Non-Goals
+- Not a general-purpose "run any command everywhere" console — this is scoped to deploying/removing signed remediation snippets.
+- Not a replacement for real fixes — snippets are temporary; every active snippet should have a tracking issue and an expiry.
+- No arbitrary-PHP paste-from-a-textbox-by-anyone. Deploy is gated to authorized operators and signed by an offline/HSM-ish key held only by OpsOasis.
+- Not a pull/poll model (see §3 for why).
+
+---
+
+## 3. Trust Model — the load-bearing decision
+
+**Principle: capability by membership, not by credential.**
+
+Atlantis is a **public repo**. Anyone can install it. That kills the pull model:
+
+- A pull model has the site call OpsOasis and say *"I'm a Team 51 site, give me code."*
+  OpsOasis then has to authenticate an untrusted claim. Any secret shipped in the public
+  plugin is not secret; a per-site secret in `wp-config` just moves the bootstrap/rotation
+  problem upstream.
+- Worse, **signing does not give confidentiality.** A signed *pull* manifest would still be
+  *readable* by any public install that fetched it — leaking our remediation code and, by
+  extension, the vulnerabilities it patches.
+
+A **push** model dissolves both problems:
+
+- **Membership is not claimed by the site — it is known by OpsOasis.** The authoritative roster is the WPCOM partner / Jetpack-connected set (`get_wpcom_jetpack_sites()`). A random Atlantis install is simply never in the push list. There is no door to knock on.
+- **Confidentiality comes free:** code is only ever deposited into sites OpsOasis already controls. It is never served to an anonymous caller.
+
+Two orthogonal properties, both required, each from a different mechanism:
+
+| Property | Protects against | Provided by |
+| --- | --- | --- |
+| **Confidentiality** | non–Team-51 sites *seeing* the code | **push-only delivery** |
+| **Authenticity / integrity** | a site running *forged/tampered* code | **Ed25519 signature** |
+
+The site is a **passive recipient**: it never initiates, never asks OpsOasis for anything. It validates a signature on what it is handed, then stores/loads it.
+
+---
+
+## 4. Architecture Overview
+
+```
+Operator
+  │  team51 wpcom:atlantis-snippet-deploy ./fix.php --canary … --yes
+  ▼
+team51-cli  (Symfony Console)
+  │  collects site-id list (get_wpcom_jetpack_sites, filters)
+  │  one batch POST  →  API_Helper::make_wpcom_request()
+  ▼
+OpsOasis  POST wpcomsp/wpcom/v1/sites/batch/atlantis-snippet-deploy
+  │  - signs payload with Ed25519 PRIVATE key (held only here)
+  │  - Amphp concurrent fan-out over the managed roster
+  │  - per-site call via WPCOM v1.2 REST proxy + blog/partner token
+  ▼
+Each managed site POST  a8csp-atlantis/v1/snippets (Atlantis REST receiver)
+  │  - verify Ed25519 signature against PUBLIC key baked into Atlantis
+  │  - store snippet record (custom table)
+  │  - materialize as mu-plugin file (or mark active for in-process loader)
+  ▼
+Atlantis runtime
+  - loads active, verified snippets (try/catch per snippet)
+  - auto-disables a snippet that fatals; global kill switch respected
+```
+
+Nothing in this path lets a non-managed site receive a snippet, and nothing lets a
+managed site run an unsigned one.
+
+---
+
+## 5. Delivery Path
+
+### 5.1 CLI — `team51-cli`
+
+New command `commands/WPCOM_Atlantis_Snippet_Deploy.php`
+(`#[AsCommand(name: 'wpcom:atlantis-snippet-deploy')]`), mirroring `Jetpack_Plugin_Update`:
+
+```
+team51 wpcom:atlantis-snippet-deploy <path-to-snippet.php>
+    [--id=<slug>]            # stable id; re-deploying same id = update
+    [--site=<id|domain>]     # canary: single site
+    [--tag=<sticker>]        # target a cohort (e.g. woocommerce sites)
+    [--expires=<iso8601>]    # auto-expiry
+    [--dry-run]
+    [--yes]
+```
+
+- Reads the snippet file locally.
+- Resolves target set from `get_wpcom_jetpack_sites()` (+ filters). Exact-match cohorts only — no fuzzy fleet-wide writes (guardrail from #138).
+- Sends **one** batch request; the server does the parallelism.
+- Prints a `Site | Result | Version | Hash` table; non-zero exit on any failure.
+
+Companion commands (thin, same helper file `includes/functions-wpcom.php`): `wpcom:atlantis-snippet-list`, `wpcom:atlantis-snippet-remove <id>`, `wpcom:atlantis-snippet-status` (which sites have which snippets active — reuses the atlantis-status batch shape).
+
+### 5.2 OpsOasis endpoint
+
+New route in `plugins/opsoasis-endpoints/src/WordPressCOM/Sites_Controller.php`:
+
+```
+POST wpcomsp/wpcom/v1/sites/batch/atlantis-snippet-deploy
+  body: { sites: [ids], id, code, expires?, notes? }
+  - guarded by update_item_permissions_check (authorized operators only)
+  - SIGN: signature = sodium_crypto_sign_detached( canonical(payload), PRIVATE_KEY )
+      PRIVATE_KEY stored as an encrypted OpsOasis secret (wpcomsp_get_encrypted_option)
+  - fan out via opsoasis_make_wpcom_api_concurrent_requests()
+      to rest/v1.2/sites/$site/… proxied to a8csp-atlantis/v1/snippets
+  - returns per-site { stored, hash, error? }
+```
+
+Sibling routes: `…/atlantis-snippet-remove`, `…/batch/atlantis-snippet-status` (the status one can piggyback on the existing atlantis-status batch by adding a `snippets` block to the Atlantis status payload).
+
+Reconciliation (phase 2): an Action Scheduler background task (`opsoasis_schedule_background_task`) that periodically diffs desired-vs-actual snippet state across the roster and re-pushes drift — closes the offline/new-site gap. All OpsOasis-initiated; still zero inbound trust.
+
+### 5.3 Atlantis REST receiver
+
+New `Snippets` module (extends `AbstractModule`) exposing:
+
+```
+POST a8csp-atlantis/v1/snippets           # deposit (create/update)
+DELETE a8csp-atlantis/v1/snippets/<id>    # remove
+GET  a8csp-atlantis/v1/snippets           # list (for status batch)
+```
+
+- Auth: same posture as the existing status controller — `manage_options` /  Jetpack-tunneled WPCOM partner calls. **Plus** the signature check below, which is the real gate. (REST auth stops randoms from poking the endpoint; the signature stops a compromised transport from planting code.)
+- On deposit: verify signature → persist → materialize (see §7).
+
+---
+
+## 6. Payload Format & Signing
+
+### 6.1 Envelope
+
+```json
+{
+  "id": "wc-94-checkout-coupon-total",
+  "version": 3,
+  "code": "<?php add_filter( 'woocommerce_calculated_total', /* … */ );",
+  "created": "2026-07-18T14:00:00Z",
+  "expires": "2026-08-01T00:00:00Z",
+  "notes": "WC 9.4 coupon total regression; tracking: PROJ-1234",
+  "sha256": "<hex of code>"
+}
+```
+
+The **signed message** is a canonical serialization of the envelope *minus* the signature field (stable key order, no incidental whitespace) so the site verifies exactly what was signed.
+
+### 6.2 Keys
+
+- **Ed25519** via libsodium (`sodium_crypto_sign_*`). Atlantis already depends on libsodium (Messages encryption uses `sodium_crypto_secretbox`), so no new dependency.
+- **Private key**: generated offline, stored **only** in OpsOasis as an encrypted secret. Never in the plugin, never in the CLI.
+- **Public key (verify-only)**: baked into the Atlantis repo as a constant. Public by design — a public key in a public repo is fine. Support a small **array** of public keys to allow rotation (accept old+new during a rotation window).
+
+### 6.3 Why signing, given push already restricts delivery
+
+Defense in depth. Push protects confidentiality and normal-path integrity, but the site's REST receiver is still a network endpoint. Signing means that even if someone reached the receiver (proxy bug, stolen partner token, compromised OpsOasis DB row), they **still** cannot make a site execute code without the offline private key. Auth gates *who can knock*; the signature gates *what can run*.
+
+---
+
+## 7. Execution & Resilience (on-site)
+
+### 7.1 Source of truth vs. materialized artifact
+
+The single most important on-site invariant:
+
+> **The DB row is the durable source of truth. The mu-plugin file is a re-creatable > cache of it.**
+
+- **DB record** (`wp_a8csp_atlantis_snippets`, §8) is what a push actually writes. It lives in the database, which **code deploys do not touch** — so active snippets survive normal DeployHQ deployments, plugin updates, and filesystem resets.
+- **mu-plugin file** is a materialization of an `active` DB row, written for the load-timing and audit benefits below. It can be wiped (by a clean deploy sync, a filesystem reset, etc.) and the site self-heals it (§7.3).
+
+Nothing here is committed to any site repo — neither the loader nor the snippet files. See
+§7.4.
+
+### 7.2 Delivery form — materialize as an mu-plugin file (recommended default)
+
+- A verified `active` snippet is written to `wp-content/mu-plugins/atlantis-snippets/<id>.php` with a header comment (id, version, hash, expiry, deployed-at).
+- A **loader drop-in** (`wp-content/mu-plugins/atlantis-snippets-loader.php`) `require`s each materialized snippet inside a `try/catch(\Throwable)`, so one bad snippet skips itself rather than fataling the site — the exact pattern from commit `f543e18` ("survive mid-update autoload races").
+- **Why mu-plugin:** loads *before* regular plugins (can intercept hooks a regular plugin — including Atlantis — would be too late for), always-on (a site owner can't toggle it off), native `include` (real `file:line` in traces, opcache-friendly, greppable/auditable on the box), and file-drop = deploy / file-delete = remove.
+
+### 7.3 The loader is a self-installed drop-in — reconcile on init
+
+We do **not** ship the loader to site repos. Atlantis, which is already installed on every site, **plants its own drop-in** (the same pattern caching plugins use for `object-cache.php`):
+
+```php
+// on activation, and defensively on init if missing
+if ( ! file_exists( WPMU_PLUGIN_DIR . '/atlantis-snippets-loader.php' ) ) {
+    copy( __DIR__ . '/stubs/snippets-loader.php', WPMU_PLUGIN_DIR . '/atlantis-snippets-loader.php' );
+}
+```
+
+On every init, Atlantis runs a cheap **reconcile pass** that makes the filesystem match the DB:
+
+> for each `active` snippet row: ensure `mu-plugins/atlantis-snippets/<id>.php` exists and its
+> hash matches; (re)materialize if missing/stale. For each non-`active`/removed row or orphan
+> file: delete the file. Ensure the loader drop-in exists.
+
+Consequences:
+
+- **Survives deploys.** A clean deploy that wipes runtime drop-ins is transparent — the DB rows persist and the next request re-materializes everything. The push had to happen *once*; durability is the DB + reconcile, not anything in a repo.
+- **Self-repairing.** Manual tampering, partial filesystem resets, and mid-update races all converge back to the DB-declared state.
+- **Clean uninstall.** Atlantis uninstall removes the snippet files *and* the loader drop-in so nothing outlives the plugin.
+
+### 7.4 Repo impact — none for site repos
+
+- The loader drop-in and per-snippet files are **runtime-materialized**, never committed. No edit to any of the hundreds of site repos.
+- Deploy hygiene: add the snippets dir + loader to the deploy-side `.gitignore` so runtime-materialized files don't surface as a dirty working tree that blocks a deploy.
+- Only the three tool repos (`a8csp-atlantis`, `opsoasis`, `team51-cli`) change, and Atlantis reaches sites via its normal release.
+
+### 7.5 Guardrails (reuse existing resilience philosophy)
+
+1. **Signature re-check** before every materialization; refuse on mismatch/expiry.
+2. **`try/catch(\Throwable)` per snippet** — a fatal in one is logged, and that snippet is  quarantined (`status = quarantined`, auto-disabled after N consecutive fatals), never the whole site.
+3. **Global kill switch** — a single option / remote flag (piggybacking the autoupdates  settings fetch) that disables the loader entirely. This is the "oh no" button.
+4. **Expiry** — expired snippets are inert and cleaned up by the reconcile pass.
+5. **Front-end safety** — like Autoupdates skips front-end init, the loader and reconcile pass must be cheap; heavy work stays off the hot path.
+
+### 7.6 Filesystem-writability fallback
+
+mu-plugin materialization needs `wp-content/mu-plugins/` writable by the web process (fine on Pressable / WPCOM Atomic in the common case, but confirm per host). Where it is **not** writable, the same DB row is loaded **in-process** from Atlantis's own bootstrap instead (`eval`/`require` the stored code). This loses the early-load timing and some auditability, so it is a per-host fallback, not the default. The DB-as-source-of-truth model means both paths read the identical record — only the execution surface differs.
+
+---
+
+## 8. Data Model
+
+Custom table `wp_a8csp_atlantis_snippets` (dbDelta, mirrors the Messages table pattern). This table is the **on-site source of truth** (§7.1): a push writes a row here; the mu-plugin file is a materialized cache of `active` rows and is rebuilt from this table by the reconcile pass. Because it lives in the DB, it survives code deploys and filesystem resets.
+
+| column | notes |
+| --- | --- |
+| `id` (varchar, unique) | stable slug, e.g. `wc-94-checkout-coupon-total` |
+| `version` (int) | bumps on redeploy of same id |
+| `code` (longtext) | the PHP (optionally stored encrypted at rest) |
+| `sha256` (char 64) | integrity check / dedupe |
+| `signature` (text) | detached Ed25519 signature (base64) |
+| `status` (varchar) | `active` / `quarantined` / `expired` / `removed` |
+| `expires_at` (datetime, null) | auto-expiry |
+| `deployed_at` / `updated_at` | audit |
+| `last_error` (text, null) | last fatal captured by the loader |
+
+Module settings (`a8csp_module_snippets`) hold: enabled flag, global kill switch, public key set, quarantine threshold.
+
+---
+
+## 9. Management Surface
+
+### Atlantis wp-cli (per-site handle without SSH-spelunking)
+```
+wp atlantis snippet list                 # active snippets + hashes + status
+wp atlantis snippet verify [<id>]        # re-check signatures
+wp atlantis snippet remove <id>          # local removal
+wp atlantis snippet flush                # nuke all (local kill switch)
+wp atlantis snippet show <id>            # dump code + metadata for audit
+```
+
+### Fleet (CLI → OpsOasis batch)
+- `wpcom:atlantis-snippet-deploy` / `-remove` / `-list` / `-status`
+- Status view = which sites run which snippet versions (drift detection).
+
+### Audit
+Every deploy/remove records operator, timestamp, target set, and hash — on the OpsOasis side (source of truth) and echoed into each site's snippet record + a WP action log.
+
+---
+
+## 10. Rollout & Safety Protocol
+
+1. **Author** the snippet locally; it must be a self-contained, idempotent mu-plugin unit.
+2. **Canary** — `--site` (or `--tag=canary`) to a handful of sites first; verify.
+3. **Cohort/fleet** — expand by sticker/tag or full roster.
+4. **Observe** — `snippet-status` for drift; PHP error monitoring (`pressable_get_php_errors` / WPCOM logs) for regressions.
+5. **Expire/Remove** — set `--expires`, or `snippet-remove <id>` when the real fix ships.
+6. **Kill switch** — global flag disables all snippets fleet-wide in one action, delivered over the existing autoupdates-settings fetch channel so it applies even if the deploy path is unhappy.
+
+---
+
+## 11. Security Considerations
+
+- **Blast radius:** arbitrary PHP on hundreds of production sites. Treat the OpsOasis private key like a production signing key: encrypted at rest, access-logged, rotatable.
+- **Operator gating:** only specific OpsOasis roles can hit the deploy endpoint; the CLI requires the existing OpsOasis credential (1Password app password).
+- **No sandbox illusion:** PHP `eval`/mu-plugin code runs with full web-process privileges. We are *not* claiming to sandbox it — safety comes from signing + canary + kill switch + expiry + audit, not from constraining what the code can do.
+- **Key rotation:** support an array of accepted public keys so we can roll the signing key without a synchronized flag day.
+- **Supply-chain framing:** this endpoint is, by design, a fleet-wide code-execution capability. It deserves the same review rigor as a release-signing pipeline.
+
+---
+
+## 12. Open Questions
+
+1. **mu-plugin file vs. in-process load** — *Decided:* file is the default (early load + audit); in-process is a per-host fallback where `mu-plugins/` isn't writable (§7.6). Left open only: is there any host in our fleet where the file path is unavailable?
+2. **Encrypt `code` at rest** in the site DB? Low marginal value (it runs anyway) but cheap given the existing Messages encryption. Decide.
+3. **Targeting model** — full roster vs. WPCOM stickers/tags for cohorts (e.g. only WooCommerce sites). Do we already have a clean "WooCommerce sites" sticker?
+4. **Fleet reconciliation cadence** — note this is distinct from the *on-site* reconcile (DB→filesystem, §7.3), which is always-on in v1. The open question is the *fleet-level* loop (OpsOasis diffing desired-vs-actual across the roster to catch offline/new sites, §5.2): push-once + manual re-run for v1, or the Action Scheduler loop from day one? (Suggest: v1 push-once, v2 fleet reconcile.)
+5. **Approval flow** — does a fleet-wide deploy need a second-operator sign-off, or is canary discipline + audit sufficient?
+6. **Parameterized-primitive convenience layer** — optionally allow the simple `{type:add_filter, hook, return}` toggles (no `eval`) as a lower-risk fast path for the easy cases, riding the same delivery/signing rails. Nice-to-have, not required for v1.
+
+---
+
+## 13. Implementation Phases
+
+- **Phase 0 — spike:** generate keypair; hardcode public key in a branch; hand-craft a signed payload; prove one site verifies + materializes + loads + survives a deliberately broken snippet.
+- **Phase 1 — Atlantis Snippets module:** custom table (source of truth), REST receiver, signature verify, self-installed loader drop-in, mu-plugin materializer, on-site reconcile-on-init (DB→filesystem), try/catch loader, kill switch, uninstall cleanup, wp-cli commands.
+- **Phase 2 — OpsOasis endpoint:** signing, batch fan-out, deploy/remove/status routes, operator gating, audit.
+- **Phase 3 — CLI commands:** deploy/remove/status with canary/dry-run/expiry.
+- **Phase 4 — fleet reconcile loop + cohort targeting + (optional) primitive convenience layer.**
+
+Phases 1–3 are implemented in the branches this doc ships with (see §15). Phase 4 and the hardening items in §14 are open.
+
+---
+
+## 14. Wire format & signing specification (as built)
+
+The three repos must agree byte-for-byte on the signed message, or every verification fails. This is the normative spec.
+
+### 14.1 Deploy payload (OpsOasis → each site `POST a8csp-atlantis/v1/snippets`)
+
+```json
+{
+  "snippet_id": "wc-94-checkout-total",
+  "version":    1752845200,
+  "code":       "<base64 of the raw PHP file bytes>",
+  "sha256":     "<lowercase hex sha256 of the raw code bytes>",
+  "expires":    "2026-08-01T00:00:00Z",   // or ""
+  "notes":      "WC 9.4 coupon total regression; PROJ-1234",
+  "signature":  "<base64 detached Ed25519 signature>"
+}
+```
+
+- **code** is carried as base64 so the PHP survives JSON/HTTP/DB byte-for-byte. The site base64-decodes it and writes the exact bytes to `mu-plugins/atlantis-snippets/<id>.php`.
+- The site **recomputes** sha256 over the decoded bytes and rejects on mismatch.
+
+### 14.2 Canonical signed messages
+
+The Ed25519 signature is over these exact strings (LF-joined, no trailing newline). The content is bound via `sha256`, so signing this short header is equivalent to signing the code.
+
+```
+deploy:  "a8csp-atlantis-snippet-deploy" LF "v1" LF <snippet_id> LF <version> LF <sha256> LF <expires>
+remove:  "a8csp-atlantis-snippet-remove" LF "v1" LF <snippet_id> LF <version>
+```
+
+`<version>` is the integer rendered as a decimal string; `<expires>` is the ISO-8601 string or empty. Implemented identically in `Signature::deploy_message()`/`remove_message()` (Atlantis) and `Atlantis_Snippets_Controller::deploy_message()`/`remove_message()` (OpsOasis).
+
+### 14.3 Replay protection
+
+`version` is monotonic per `snippet_id`. The CLI defaults it to the current Unix timestamp. A site rejects a deploy whose version ≤ the stored version, and a removal whose version ≤ the stored version — so an old signed payload cannot be replayed to downgrade or un-remove.
+
+### 14.4 Key provisioning runbook
+
+1. Generate an Ed25519 keypair (once), e.g. via libsodium `sodium_crypto_sign_keypair()`.
+2. **Private key** → store on OpsOasis, encrypted, from a non-web context (the secrets registry guard rejects web-context writes): `wp eval "wpcomsp_update_encrypted_option('opsoasis_atlantis_snippet_signing_key', ['secret_key' => '<hex secret key>']);"`
+3. **Public key** → add the hex to `Signature::DEFAULT_PUBLIC_KEYS` in Atlantis and ship it in the release. Until this is done, verification fails closed and nothing is deployable (safe default). Sites may also set `A8CSP_ATLANTIS_SNIPPET_PUBLIC_KEYS` in wp-config to add/override keys. The array form supports rotation (accept old+new during a window).
+
+---
+
+## 15. Appendix — File inventory (as built)
+
+**a8csp-atlantis** (branch `add/fleet-snippet-runner`):
+- `src/Modules/Snippets/CustomTable.php` — `wp_a8csp_atlantis_snippets` schema (source of truth)
+- `src/Modules/Snippets/SnippetStore.php` — data-access layer (upsert/remove/status/failure)
+- `src/Modules/Snippets/Signature.php` — verify-only Ed25519 + canonical messages + public keys
+- `src/Modules/Snippets/Loader.php` — materialize + reconcile-on-init + can_materialize
+- `src/Modules/Snippets/DropIn.php` — self-installed loader drop-in + kill-switch marker
+- `src/Modules/Snippets/stubs/snippets-loader.php` — the mu-plugin loader template
+- `src/Modules/Snippets/Snippets.php` — the module (extends AbstractModule)
+- `src/REST/Snippets_Controller.php` — REST receiver (deploy / remove / list)
+- `src/CLI/Snippet_Command.php` — `wp atlantis snippet list|show|verify|remove|flush|reconcile|disable|enable`
+- `includes/module-snippets.php` — helper wrappers (incl. loader failure hook)
+- wired in `src/Modules.php` (register module) and `src/Plugin.php` (register wp-cli command)
+- `docs/snippet-runner-design.md` — this document
+
+**opsoasis** (branch `add/fleet-snippet-runner`):
+- `plugins/opsoasis-endpoints/src/WordPressCOM/Atlantis_Snippets_Controller.php` — signing + `sites/batch/atlantis-snippet-deploy` / `-remove` / `-status` fan-out
+- wired in `plugins/opsoasis-endpoints/src/Plugin.php`
+- signing key stored via existing `wpcomsp_update_encrypted_option()` (no new secret plumbing)
+
+**team51-cli** (branch `add/fleet-snippet-runner`):
+- `commands/WPCOM_Atlantis_Snippet_Deploy.php` — `wpcom:atlantis-snippet-deploy <file>` (php -l gate, canary, dry-run, expiry)
+- `commands/WPCOM_Atlantis_Snippet_Remove.php` — `wpcom:atlantis-snippet-remove <id>`
+- `commands/WPCOM_Atlantis_Snippet_Status.php` — `wpcom:atlantis-snippet-status` (drift/issues)
+- `includes/functions-wpcom.php` — `deploy_/remove_/get_..._atlantis_snippet_status_batch()` helpers
+
+**Reference precedents:**
+- opsoasis#390 / team51-cli#138 (plugin-update batch) — reach + trust pattern
+- `sites/batch/atlantis-status` → `a8csp-atlantis/v1/status` — read-side twin this mirrors
+- Autoupdates settings fetch — remote-config + kill-switch channel
+- commit `f543e18` — per-unit try/catch resilience pattern
+- `Plugin::register_core_compat_filters()` (the `wp_img_tag_add_auto_sizes` mitigation) — the hardcoded, release-gated pattern this feature generalizes

--- a/includes/module-snippets.php
+++ b/includes/module-snippets.php
@@ -1,0 +1,48 @@
+<?php declare( strict_types=1 );
+
+use A8C\SpecialProjects\Atlantis\Modules\Snippets\Snippets;
+use A8C\SpecialProjects\Atlantis\Plugin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Returns the Snippets module instance if it is registered and initialised.
+ *
+ * @since   1.3.0
+ * @version 1.3.0
+ *
+ * @return  Snippets|null
+ */
+function a8csp_atlantis_get_snippets_module(): ?Snippets {
+	$plugin = Plugin::get_instance();
+	if ( ! isset( $plugin->modules ) ) {
+		return null;
+	}
+
+	$module = $plugin->modules->modules['snippets'] ?? null;
+	return $module instanceof Snippets ? $module : null;
+}
+
+/**
+ * Records a runtime failure for a snippet so Atlantis can auto-quarantine it.
+ *
+ * Called by the mu-plugin loader drop-in when a snippet throws while loading.
+ * Guarded so the loader can call it conditionally without hard-depending on
+ * Atlantis being fully initialised.
+ *
+ * @since   1.3.0
+ * @version 1.3.0
+ *
+ * @param   string $snippet_id The stable snippet slug.
+ * @param   string $error      The error message.
+ *
+ * @return  void
+ */
+function a8csp_atlantis_record_snippet_failure( string $snippet_id, string $error ): void {
+	$module = a8csp_atlantis_get_snippets_module();
+	if ( null === $module ) {
+		return;
+	}
+
+	$module->get_store()->record_failure( $snippet_id, $error );
+}

--- a/src/CLI/Snippet_Command.php
+++ b/src/CLI/Snippet_Command.php
@@ -1,0 +1,324 @@
+<?php declare( strict_types=1 );
+
+namespace A8C\SpecialProjects\Atlantis\CLI;
+
+use A8C\SpecialProjects\Atlantis\Modules\Snippets\Loader;
+use A8C\SpecialProjects\Atlantis\Modules\Snippets\Signature;
+use A8C\SpecialProjects\Atlantis\Modules\Snippets\SnippetStore;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Inspect and manage deployed Atlantis remediation snippets on this site.
+ *
+ * These are the per-site handle on the fleet snippet runner: list what is
+ * active, audit a snippet's code, re-check signatures, remove one locally, or
+ * throw the local kill switch — all without SSH-spelunking the filesystem.
+ *
+ * ## EXAMPLES
+ *
+ *     # List every snippet stored on this site.
+ *     $ wp atlantis snippet list
+ *
+ *     # Show one snippet's code and metadata for audit.
+ *     $ wp atlantis snippet show wc-94-checkout-total
+ *
+ *     # Re-verify stored signatures against stored code.
+ *     $ wp atlantis snippet verify
+ *
+ *     # Remove one snippet locally and clear its file.
+ *     $ wp atlantis snippet remove wc-94-checkout-total
+ *
+ *     # Engage the local kill switch (disables all snippets at once).
+ *     $ wp atlantis snippet disable
+ *
+ * @since   1.3.0
+ * @version 1.3.0
+ */
+class Snippet_Command {
+	/**
+	 * Default fields returned by `list`.
+	 *
+	 * @var array<int, string>
+	 */
+	private const DEFAULT_FIELDS = array( 'snippet_id', 'version', 'status', 'fail_count', 'expires_at' );
+
+	// region SUBCOMMANDS
+
+	/**
+	 * Lists every snippet stored on this site.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--fields=<fields>]
+	 * : Comma-separated list of fields to show.
+	 * ---
+	 * default: snippet_id,version,status,fail_count,expires_at
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Render output in the given format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 *   - count
+	 * ---
+	 *
+	 * @subcommand list
+	 *
+	 * @param array<int, string>         $args       Positional args (unused).
+	 * @param array<string, string|bool> $assoc_args Flags.
+	 */
+	public function list_( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$rows = array();
+		foreach ( $this->store()->all() as $row ) {
+			$rows[] = array(
+				'snippet_id' => $row['snippet_id'],
+				'version'    => (int) $row['version'],
+				'status'     => $row['status'],
+				'sha256'     => $row['sha256'],
+				'fail_count' => (int) $row['fail_count'],
+				'expires_at' => $row['expires_at'] ?? '',
+				'updated_at' => $row['updated_at'],
+			);
+		}
+
+		$fields = isset( $assoc_args['fields'] )
+			? \array_map( 'trim', \explode( ',', (string) $assoc_args['fields'] ) )
+			: self::DEFAULT_FIELDS;
+
+		$formatter = new \WP_CLI\Formatter( $assoc_args, $fields );
+		$formatter->display_items( $rows );
+	}
+
+	/**
+	 * Shows a single snippet's metadata and code.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <snippet_id>
+	 * : The snippet id.
+	 *
+	 * @param array<int, string>         $args       Positional args: <snippet_id>.
+	 * @param array<string, string|bool> $assoc_args Flags (unused).
+	 */
+	public function show( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$row = $this->require_snippet( $args[0] ?? '' );
+
+		\WP_CLI::log( \sprintf( 'ID:         %s', $row['snippet_id'] ) );
+		\WP_CLI::log( \sprintf( 'Version:    %d', (int) $row['version'] ) );
+		\WP_CLI::log( \sprintf( 'Status:     %s', $row['status'] ) );
+		\WP_CLI::log( \sprintf( 'SHA-256:    %s', $row['sha256'] ) );
+		\WP_CLI::log( \sprintf( 'Fail count: %d', (int) $row['fail_count'] ) );
+		\WP_CLI::log( \sprintf( 'Expires:    %s', $row['expires_at'] ?? '(never)' ) );
+		\WP_CLI::log( \sprintf( 'Deployed:   %s', $row['deployed_at'] ) );
+		if ( ! is_null( $row['notes'] ) && '' !== $row['notes'] ) {
+			\WP_CLI::log( \sprintf( 'Notes:      %s', $row['notes'] ) );
+		}
+		if ( ! is_null( $row['last_error'] ) && '' !== $row['last_error'] ) {
+			\WP_CLI::log( \sprintf( 'Last error: %s', $row['last_error'] ) );
+		}
+		\WP_CLI::log( '' );
+		\WP_CLI::log( '--- code ---' );
+		\WP_CLI::log( (string) $row['code'] );
+	}
+
+	/**
+	 * Re-verifies stored signatures against stored code and hashes.
+	 *
+	 * Reports per-snippet. Exits non-zero if any snippet fails verification.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<snippet_id>]
+	 * : Verify a single snippet. Omit to verify all.
+	 *
+	 * @param array<int, string>         $args       Positional args: optional <snippet_id>.
+	 * @param array<string, string|bool> $assoc_args Flags (unused).
+	 */
+	public function verify( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$rows = isset( $args[0] ) && '' !== $args[0]
+			? array( $this->require_snippet( $args[0] ) )
+			: $this->store()->all();
+
+		if ( 0 === \count( $rows ) ) {
+			\WP_CLI::log( 'No snippets stored.' );
+			return;
+		}
+
+		$failures = 0;
+		foreach ( $rows as $row ) {
+			$snippet_id = (string) $row['snippet_id'];
+
+			if ( $this->row_signature_valid( $row ) ) {
+				\WP_CLI::success( \sprintf( "Snippet '%s' verified.", $snippet_id ) );
+			} else {
+				\WP_CLI::warning( \sprintf( "Snippet '%s' FAILED verification.", $snippet_id ) );
+				++$failures;
+			}
+		}
+
+		if ( 0 < $failures ) {
+			\WP_CLI::halt( 1 );
+		}
+	}
+
+	/**
+	 * Recomputes a snippet's hash and verifies its stored signature.
+	 *
+	 * @param array<string, mixed> $row The snippet row.
+	 *
+	 * @return bool
+	 */
+	private function row_signature_valid( array $row ): bool {
+		$hash_ok = hash_equals( hash( 'sha256', (string) $row['code'] ), (string) $row['sha256'] );
+		if ( ! $hash_ok ) {
+			return false;
+		}
+
+		$expires = ( is_null( $row['expires_at'] ) || '' === $row['expires_at'] ) ? '' : gmdate( 'c', (int) strtotime( (string) $row['expires_at'] ) );
+		$message = Signature::deploy_message( (string) $row['snippet_id'], (int) $row['version'], (string) $row['sha256'], $expires );
+
+		return Signature::verify( $message, (string) $row['signature'] );
+	}
+
+	/**
+	 * Removes a snippet locally and clears its materialized file.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <snippet_id>
+	 * : The snippet id to remove.
+	 *
+	 * @param array<int, string>         $args       Positional args: <snippet_id>.
+	 * @param array<string, string|bool> $assoc_args Flags (unused).
+	 */
+	public function remove( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$row = $this->require_snippet( $args[0] ?? '' );
+
+		$this->store()->set_status( (string) $row['snippet_id'], 'removed' );
+		$this->loader()->reconcile();
+
+		\WP_CLI::success( \sprintf( "Snippet '%s' removed locally.", $row['snippet_id'] ) );
+	}
+
+	/**
+	 * Deletes every snippet on this site and purges the loader drop-in and files.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--yes]
+	 * : Skip the confirmation prompt.
+	 *
+	 * @param array<int, string>         $args       Positional args (unused).
+	 * @param array<string, string|bool> $assoc_args Flags.
+	 */
+	public function flush( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		\WP_CLI::confirm( 'Delete ALL Atlantis snippets on this site and remove the loader?', $assoc_args );
+
+		foreach ( $this->store()->all() as $row ) {
+			$this->store()->delete( (string) $row['snippet_id'] );
+		}
+
+		$this->loader()->purge_filesystem();
+
+		\WP_CLI::success( 'All snippets flushed.' );
+	}
+
+	/**
+	 * Forces a reconcile pass (re-materialize the filesystem from the database).
+	 *
+	 * @param array<int, string>         $args       Positional args (unused).
+	 * @param array<string, string|bool> $assoc_args Flags (unused).
+	 */
+	public function reconcile( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$this->loader()->reconcile();
+		\WP_CLI::success( 'Reconciled snippet files with the database.' );
+	}
+
+	/**
+	 * Engages the local kill switch: disables all snippets at once.
+	 *
+	 * @param array<int, string>         $args       Positional args (unused).
+	 * @param array<string, string|bool> $assoc_args Flags (unused).
+	 */
+	public function disable( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		update_option( 'a8csp_atlantis_snippets_killswitch', true );
+		$this->loader()->reconcile();
+		\WP_CLI::success( 'Snippet kill switch ENGAGED. All snippets are disabled on this site.' );
+	}
+
+	/**
+	 * Releases the local kill switch: re-enables snippet loading.
+	 *
+	 * @param array<int, string>         $args       Positional args (unused).
+	 * @param array<string, string|bool> $assoc_args Flags (unused).
+	 */
+	public function enable( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		update_option( 'a8csp_atlantis_snippets_killswitch', false );
+		$this->loader()->reconcile();
+		\WP_CLI::success( 'Snippet kill switch released. Snippets re-enabled on this site.' );
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Returns the snippet store, or aborts if the module is unavailable.
+	 *
+	 * @return SnippetStore
+	 */
+	private function store(): SnippetStore {
+		return $this->require_module()->get_store();
+	}
+
+	/**
+	 * Returns the loader, or aborts if the module is unavailable.
+	 *
+	 * @return Loader
+	 */
+	private function loader(): Loader {
+		return $this->require_module()->get_loader();
+	}
+
+	/**
+	 * Returns the Snippets module, or aborts with an error.
+	 *
+	 * @return \A8C\SpecialProjects\Atlantis\Modules\Snippets\Snippets
+	 */
+	private function require_module(): \A8C\SpecialProjects\Atlantis\Modules\Snippets\Snippets {
+		$module = a8csp_atlantis_get_snippets_module();
+		if ( null === $module ) {
+			\WP_CLI::error( 'The Atlantis Snippets module is not active on this site.' );
+		}
+
+		return $module;
+	}
+
+	/**
+	 * Resolves a snippet id to its row or aborts with an error.
+	 *
+	 * @param string $snippet_id The snippet id.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function require_snippet( string $snippet_id ): array {
+		if ( '' === $snippet_id ) {
+			\WP_CLI::error( 'A snippet id is required.' );
+		}
+
+		$row = $this->store()->get( $snippet_id );
+		if ( null === $row ) {
+			\WP_CLI::error( \sprintf( "Unknown snippet '%s'.", $snippet_id ) );
+		}
+
+		return $row;
+	}
+
+	// endregion
+}

--- a/src/Modules.php
+++ b/src/Modules.php
@@ -7,6 +7,7 @@ use A8C\SpecialProjects\Atlantis\Modules\Tracking\Tracking;
 use A8C\SpecialProjects\Atlantis\Modules\Autoupdates\AutoUpdatePluginsFilter;
 use A8C\SpecialProjects\Atlantis\Modules\AbstractModule;
 use A8C\SpecialProjects\Atlantis\Modules\Messages\Messages;
+use A8C\SpecialProjects\Atlantis\Modules\Snippets\Snippets;
 
 
 defined( 'ABSPATH' ) || exit;
@@ -60,6 +61,7 @@ class Modules {
 		$this->try_initialize_module( 'colophon', static fn() => new Colophon() );
 		$this->try_initialize_module( 'tracking', static fn() => new Tracking() );
 		$this->try_initialize_module( 'autoupdates', static fn() => new AutoUpdatePluginsFilter() );
+		$this->try_initialize_module( 'snippets', static fn() => new Snippets() );
 	}
 
 	/**

--- a/src/Modules/Snippets/CustomTable.php
+++ b/src/Modules/Snippets/CustomTable.php
@@ -1,0 +1,164 @@
+<?php declare( strict_types=1 );
+
+namespace A8C\SpecialProjects\Atlantis\Modules\Snippets;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles database schema management for the Snippets module.
+ *
+ * The table is the on-site source of truth for deployed remediation snippets.
+ * It lives in the database, which code deploys do not touch, so active snippets
+ * survive normal deployments and filesystem resets. The materialized mu-plugin
+ * files (see {@see Loader}) are a re-creatable cache of the `active` rows here.
+ *
+ * @since   1.3.0
+ * @version 1.3.0
+ */
+class CustomTable {
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * The name of the custom table.
+	 *
+	 * @var string
+	 */
+	protected const TABLE_NAME = 'a8csp_atlantis_snippets';
+
+	/**
+	 * Current schema version.
+	 * Increment this when making schema changes.
+	 *
+	 * @var string
+	 */
+	protected const SCHEMA_VERSION = '1.0.0';
+
+	// endregion
+
+	// region METHODS
+
+	/**
+	 * Returns the full table name including the WordPress prefix.
+	 *
+	 * @return  string
+	 */
+	public static function get_table_name(): string {
+		return $GLOBALS['wpdb']->prefix . self::TABLE_NAME;
+	}
+
+	/**
+	 * Checks if the custom table exists.
+	 *
+	 * @return  bool
+	 */
+	public static function table_exists(): bool {
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+		return $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name;
+	}
+
+	/**
+	 * Initializes the Custom Table component.
+	 *
+	 * @return  void
+	 */
+	public function initialize(): void {
+		add_action( 'init', array( $this, 'maybe_create_table' ) );
+	}
+
+	// endregion
+
+	// region HOOKS
+
+	/**
+	 * Checks if the table needs to be created or updated.
+	 *
+	 * @return  void
+	 */
+	public function maybe_create_table(): void {
+		if ( ! self::table_exists() || $this->needs_update() ) {
+			$this->update_schema();
+		}
+	}
+
+	// endregion
+
+	// region SCHEMA MANAGEMENT
+
+	/**
+	 * Creates the custom table if it does not exist, or updates it if the schema version is outdated.
+	 *
+	 * @return  void
+	 */
+	protected function update_schema(): void {
+		/* @phpstan-ignore requireOnce.fileNotFound */
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		$sql = $this->get_table_definition();
+		dbDelta( $sql );
+
+		$this->update_db_version();
+	}
+
+	/**
+	 * Get the table definition.
+	 *
+	 * @return  string
+	 */
+	protected function get_table_definition(): string {
+		global $wpdb;
+
+		$table_name      = self::get_table_name();
+		$charset_collate = $wpdb->get_charset_collate();
+
+		return "CREATE TABLE `$table_name` (
+			`id` bigint(20) NOT NULL AUTO_INCREMENT,
+			`snippet_id` varchar(191) NOT NULL,
+			`version` int(11) NOT NULL DEFAULT 0,
+			`code` longtext NOT NULL,
+			`sha256` char(64) NOT NULL,
+			`signature` text NOT NULL,
+			`status` varchar(20) NOT NULL DEFAULT 'active',
+			`notes` text DEFAULT NULL,
+			`fail_count` int(11) NOT NULL DEFAULT 0,
+			`last_error` text DEFAULT NULL,
+			`expires_at` datetime DEFAULT NULL,
+			`deployed_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			`updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			PRIMARY KEY  (`id`),
+			UNIQUE KEY `snippet_id` (`snippet_id`),
+			KEY `status` (`status`),
+			KEY `expires_at` (`expires_at`)
+		) $charset_collate;";
+	}
+
+	/**
+	 * Checks if the database schema needs to be updated.
+	 *
+	 * @return  bool
+	 */
+	protected function needs_update(): bool {
+		return \version_compare( $this->get_db_version(), self::SCHEMA_VERSION, '<' );
+	}
+
+	/**
+	 * Returns the current schema version from the database.
+	 *
+	 * @return  string
+	 */
+	protected function get_db_version(): string {
+		return get_option( 'a8csp_atlantis_snippets_schema_version', '0.0.0' );
+	}
+
+	/**
+	 * Updates the database version to the current schema version.
+	 *
+	 * @return  void
+	 */
+	protected function update_db_version(): void {
+		update_option( 'a8csp_atlantis_snippets_schema_version', self::SCHEMA_VERSION );
+	}
+
+	// endregion
+}

--- a/src/Modules/Snippets/DropIn.php
+++ b/src/Modules/Snippets/DropIn.php
@@ -1,0 +1,115 @@
+<?php declare( strict_types=1 );
+
+namespace A8C\SpecialProjects\Atlantis\Modules\Snippets;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages the self-installed mu-plugin loader drop-in and the global kill-switch
+ * marker.
+ *
+ * Atlantis owns the loader file the way caching plugins own object-cache.php:
+ * it is written (and rewritten on drift) from the shipped stub, never committed
+ * to any site repo. The `.disabled` marker is a filesystem-only kill switch the
+ * loader honors without needing the database.
+ *
+ * @since   1.3.0
+ * @version 1.3.0
+ */
+class DropIn {
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * Filename of the managed loader drop-in placed at the top level of mu-plugins.
+	 *
+	 * @var string
+	 */
+	public const LOADER_FILENAME = 'atlantis-snippets-loader.php';
+
+	/**
+	 * Option that engages the global kill switch when truthy.
+	 *
+	 * @var string
+	 */
+	private const KILLSWITCH_OPTION = 'a8csp_atlantis_snippets_killswitch';
+
+	// endregion
+
+	// region METHODS
+
+	/**
+	 * Writes the managed loader drop-in if it is missing or has drifted from the
+	 * shipped stub.
+	 *
+	 * @param   \WP_Filesystem_Base $filesystem The filesystem instance.
+	 * @param   string              $mu_dir     The mu-plugins directory.
+	 *
+	 * @return  void
+	 */
+	public function ensure_loader( \WP_Filesystem_Base $filesystem, string $mu_dir ): void {
+		if ( ! $filesystem->is_dir( $mu_dir ) ) {
+			$filesystem->mkdir( $mu_dir, FS_CHMOD_DIR );
+		}
+
+		$desired = $filesystem->get_contents( __DIR__ . '/stubs/snippets-loader.php' );
+		if ( ! is_string( $desired ) ) {
+			return;
+		}
+
+		$target  = $mu_dir . '/' . self::LOADER_FILENAME;
+		$current = $filesystem->exists( $target ) ? $filesystem->get_contents( $target ) : false;
+		if ( $current === $desired ) {
+			return;
+		}
+
+		$filesystem->put_contents( $target, $desired, FS_CHMOD_FILE );
+	}
+
+	/**
+	 * Creates or removes the `.disabled` marker based on the stored kill-switch
+	 * state.
+	 *
+	 * @param   \WP_Filesystem_Base $filesystem    The filesystem instance.
+	 * @param   string              $snippets_dir  The snippets directory.
+	 *
+	 * @return  void
+	 */
+	public function apply_killswitch( \WP_Filesystem_Base $filesystem, string $snippets_dir ): void {
+		$marker = $snippets_dir . '/.disabled';
+
+		if ( $this->is_killswitch_engaged() ) {
+			if ( ! $filesystem->exists( $marker ) ) {
+				$filesystem->put_contents( $marker, "Atlantis snippet loader disabled.\n", FS_CHMOD_FILE );
+			}
+		} elseif ( $filesystem->exists( $marker ) ) {
+			$filesystem->delete( $marker );
+		}
+	}
+
+	/**
+	 * Removes the loader drop-in file.
+	 *
+	 * @param   \WP_Filesystem_Base $filesystem The filesystem instance.
+	 * @param   string              $mu_dir     The mu-plugins directory.
+	 *
+	 * @return  void
+	 */
+	public function purge_loader( \WP_Filesystem_Base $filesystem, string $mu_dir ): void {
+		$loader = $mu_dir . '/' . self::LOADER_FILENAME;
+		if ( $filesystem->exists( $loader ) ) {
+			$filesystem->delete( $loader );
+		}
+	}
+
+	/**
+	 * Whether the global kill switch is engaged. Sourced from a local option that
+	 * the Autoupdates-style central settings channel (or an operator) can flip.
+	 *
+	 * @return  bool
+	 */
+	private function is_killswitch_engaged(): bool {
+		return (bool) get_option( self::KILLSWITCH_OPTION, false );
+	}
+
+	// endregion
+}

--- a/src/Modules/Snippets/Loader.php
+++ b/src/Modules/Snippets/Loader.php
@@ -1,0 +1,303 @@
+<?php declare( strict_types=1 );
+
+namespace A8C\SpecialProjects\Atlantis\Modules\Snippets;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Materializes deployed snippets to disk and keeps the filesystem reconciled
+ * with the database (the source of truth).
+ *
+ * Snippets are executed by a small, self-installed mu-plugin *loader drop-in*
+ * (see stubs/snippets-loader.php) rather than from within Atlantis itself. This
+ * buys two things: the snippets load *before* regular plugins (so they can
+ * intercept hooks Atlantis would be too late for), and they keep working even
+ * while Atlantis is mid-update. Atlantis verifies each snippet's signature
+ * *before* writing its file, so the loader can trust any file it finds.
+ *
+ * @since   1.3.0
+ * @version 1.3.0
+ */
+class Loader {
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * Directory (under mu-plugins) that holds the materialized snippet files.
+	 *
+	 * @var string
+	 */
+	private const SNIPPETS_DIRNAME = 'atlantis-snippets';
+
+	/**
+	 * Number of recorded runtime fatals after which a snippet is auto-quarantined.
+	 *
+	 * @var int
+	 */
+	private const QUARANTINE_THRESHOLD = 3;
+
+	/**
+	 * The snippet data store.
+	 *
+	 * @var SnippetStore
+	 */
+	private SnippetStore $store;
+
+	/**
+	 * The loader drop-in / kill-switch manager.
+	 *
+	 * @var DropIn
+	 */
+	private DropIn $dropin;
+
+	// endregion
+
+	// region MAGIC METHODS
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   SnippetStore $store The snippet data store.
+	 */
+	public function __construct( SnippetStore $store ) {
+		$this->store  = $store;
+		$this->dropin = new DropIn();
+	}
+
+	// endregion
+
+	// region PATHS
+
+	/**
+	 * Returns the mu-plugins directory, or null if it is not resolvable.
+	 *
+	 * @return  string|null
+	 */
+	private function mu_plugins_dir(): ?string {
+		if ( defined( 'WPMU_PLUGIN_DIR' ) ) {
+			return rtrim( WPMU_PLUGIN_DIR, '/\\' );
+		}
+
+		if ( defined( 'WP_CONTENT_DIR' ) ) {
+			return rtrim( WP_CONTENT_DIR, '/\\' ) . '/mu-plugins';
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the absolute path to the snippets directory, or null if mu-plugins
+	 * cannot be resolved.
+	 *
+	 * @return  string|null
+	 */
+	private function snippets_dir(): ?string {
+		$mu = $this->mu_plugins_dir();
+		return null === $mu ? null : $mu . '/' . self::SNIPPETS_DIRNAME;
+	}
+
+	/**
+	 * Returns the absolute path to a snippet's materialized file.
+	 *
+	 * @param   string $snippet_id The stable snippet slug.
+	 *
+	 * @return  string|null
+	 */
+	private function snippet_file( string $snippet_id ): ?string {
+		$dir = $this->snippets_dir();
+		return null === $dir ? null : $dir . '/' . $this->safe_basename( $snippet_id ) . '.php';
+	}
+
+	/**
+	 * Normalizes a snippet id to a filesystem-safe basename. Ids are already
+	 * validated on receipt (see Snippets_Controller); this is defense in depth.
+	 *
+	 * @param   string $snippet_id The stable snippet slug.
+	 *
+	 * @return  string
+	 */
+	private function safe_basename( string $snippet_id ): string {
+		return (string) preg_replace( '/[^a-z0-9_-]/', '', strtolower( $snippet_id ) );
+	}
+
+	// endregion
+
+	// region RECONCILE
+
+	/**
+	 * Makes the filesystem match the database:
+	 *
+	 * - ensures the loader drop-in exists;
+	 * - materializes a file for every loadable (active, unexpired) snippet whose
+	 *   file is missing or whose contents have drifted from the stored hash;
+	 * - retires expired snippets and quarantines repeatedly-fatal ones;
+	 * - removes files for any snippet that should no longer be present.
+	 *
+	 * Cheap enough to run on every `init`; the write paths only fire on drift.
+	 *
+	 * @return  void
+	 */
+	public function reconcile(): void {
+		$dir = $this->snippets_dir();
+		if ( null === $dir ) {
+			return;
+		}
+
+		$filesystem = $this->get_filesystem();
+		if ( null === $filesystem ) {
+			return; // Not writable (e.g. non-direct filesystem); nothing we can do.
+		}
+
+		if ( ! $filesystem->is_dir( $dir ) ) {
+			$filesystem->mkdir( $dir, FS_CHMOD_DIR );
+		}
+
+		$mu_dir = $this->mu_plugins_dir();
+		if ( null !== $mu_dir ) {
+			$this->dropin->ensure_loader( $filesystem, $mu_dir );
+		}
+
+		$this->dropin->apply_killswitch( $filesystem, $dir );
+		$this->retire_and_quarantine();
+
+		$loadable = $this->store->all_loadable();
+		$expected = array();
+
+		foreach ( $loadable as $row ) {
+			$snippet_id = (string) $row['snippet_id'];
+			$file       = $this->snippet_file( $snippet_id );
+			if ( null === $file ) {
+				continue;
+			}
+
+			$expected[ basename( $file ) ] = true;
+
+			$current = $filesystem->exists( $file ) ? $filesystem->get_contents( $file ) : false;
+			if ( is_string( $current ) && hash( 'sha256', $current ) === $row['sha256'] ) {
+				continue; // Already materialized and intact.
+			}
+
+			$filesystem->put_contents( $file, (string) $row['code'], FS_CHMOD_FILE );
+		}
+
+		$this->remove_unexpected_files( $filesystem, $dir, $expected );
+	}
+
+	/**
+	 * Deletes any *.php file in the snippets dir that is not in the expected set.
+	 *
+	 * @param   \WP_Filesystem_Base $filesystem The filesystem instance.
+	 * @param   string              $dir        The snippets directory.
+	 * @param   array<string, bool> $expected   Map of expected basenames.
+	 *
+	 * @return  void
+	 */
+	private function remove_unexpected_files( \WP_Filesystem_Base $filesystem, string $dir, array $expected ): void {
+		$existing = glob( $dir . '/*.php' );
+		if ( false === $existing ) {
+			return;
+		}
+
+		foreach ( $existing as $path ) {
+			if ( ! isset( $expected[ basename( $path ) ] ) ) {
+				$filesystem->delete( $path );
+			}
+		}
+	}
+
+	/**
+	 * Flags expired snippets as `expired` and auto-quarantines snippets whose
+	 * recorded fatal count has crossed the threshold.
+	 *
+	 * @return  void
+	 */
+	private function retire_and_quarantine(): void {
+		foreach ( $this->store->all() as $row ) {
+			$snippet_id = (string) $row['snippet_id'];
+
+			if ( 'active' === $row['status'] && ! is_null( $row['expires_at'] ) && '' !== $row['expires_at'] && $row['expires_at'] <= current_time( 'mysql', true ) ) {
+				$this->store->set_status( $snippet_id, 'expired' );
+				continue;
+			}
+
+			if ( 'active' === $row['status'] && (int) $row['fail_count'] >= self::QUARANTINE_THRESHOLD ) {
+				$this->store->set_status( $snippet_id, 'quarantined' );
+			}
+		}
+	}
+
+	// endregion
+
+	// region FILESYSTEM
+
+	/**
+	 * Returns a direct WP_Filesystem instance, or null when direct filesystem
+	 * access is unavailable (in which case snippets cannot be materialized and
+	 * the module is environmentally disabled — see Snippets::is_disabled()).
+	 *
+	 * @return  \WP_Filesystem_Base|null
+	 */
+	private function get_filesystem(): ?\WP_Filesystem_Base {
+		global $wp_filesystem;
+
+		if ( ! function_exists( 'WP_Filesystem' ) ) {
+			/* @phpstan-ignore requireOnce.fileNotFound */
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		if ( 'direct' !== get_filesystem_method() ) {
+			return null;
+		}
+
+		WP_Filesystem();
+		return $wp_filesystem;
+	}
+
+	/**
+	 * Whether snippet files can be written on this host (direct filesystem access
+	 * to a writable mu-plugins directory).
+	 *
+	 * @return  bool
+	 */
+	public function can_materialize(): bool {
+		$mu_dir = $this->mu_plugins_dir();
+		if ( null === $mu_dir ) {
+			return false;
+		}
+
+		$filesystem = $this->get_filesystem();
+		if ( null === $filesystem ) {
+			return false;
+		}
+
+		return $filesystem->is_dir( $mu_dir ) ? $filesystem->is_writable( $mu_dir ) : $filesystem->is_writable( dirname( $mu_dir ) );
+	}
+
+	// endregion
+
+	// region CLEANUP
+
+	/**
+	 * Removes the loader drop-in and every materialized snippet file. Used on
+	 * module teardown / plugin uninstall so nothing outlives Atlantis.
+	 *
+	 * @return  void
+	 */
+	public function purge_filesystem(): void {
+		$filesystem = $this->get_filesystem();
+		if ( null === $filesystem ) {
+			return;
+		}
+
+		$dir = $this->snippets_dir();
+		if ( null !== $dir && $filesystem->is_dir( $dir ) ) {
+			$filesystem->delete( $dir, true );
+		}
+
+		$mu_dir = $this->mu_plugins_dir();
+		if ( null !== $mu_dir ) {
+			$this->dropin->purge_loader( $filesystem, $mu_dir );
+		}
+	}
+
+	// endregion
+}

--- a/src/Modules/Snippets/Signature.php
+++ b/src/Modules/Snippets/Signature.php
@@ -1,0 +1,159 @@
+<?php declare( strict_types=1 );
+
+namespace A8C\SpecialProjects\Atlantis\Modules\Snippets;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Verify-only Ed25519 signature checks for deployed snippets.
+ *
+ * The private signing key lives only in OpsOasis. Atlantis ships one or more
+ * *public* keys (public by design — a public key in a public repo is fine) and
+ * verifies that every snippet it is asked to store or remove was signed by the
+ * holder of the corresponding private key. Authentication on the REST route
+ * gates *who can knock*; this signature gates *what can run*.
+ *
+ * The canonical signed messages are defined here and MUST be reproduced
+ * byte-for-byte by the OpsOasis signer. See the design doc bundled with this
+ * module (docs/snippet-runner-design.md) for the specification.
+ *
+ * @since   1.3.0
+ * @version 1.3.0
+ */
+class Signature {
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * Baked-in verify-only Ed25519 public keys, hex-encoded.
+	 *
+	 * Public by design. Multiple keys are supported so the signing key can be
+	 * rotated without a synchronized flag day: keep the old key here until every
+	 * site has shipped the release carrying the new one, then drop it.
+	 *
+	 * Sites may additionally override/extend this set by defining the
+	 * `A8CSP_ATLANTIS_SNIPPET_PUBLIC_KEYS` constant (array of hex strings) in
+	 * wp-config.php.
+	 *
+	 * If this set is empty, verification fails closed and nothing is deployable —
+	 * a deliberately safe default until the real key is provisioned.
+	 *
+	 * @var array<int, string>
+	 */
+	private const DEFAULT_PUBLIC_KEYS = array(
+		// TODO: Replace with the real OpsOasis snippet-signing public key (hex)
+		// before this feature is released. Until then verification fails closed.
+	);
+
+	// endregion
+
+	// region METHODS
+
+	/**
+	 * Returns the set of accepted public keys (raw binary), from the baked-in
+	 * constant plus any wp-config override.
+	 *
+	 * @return  array<int, string> Raw 32-byte Ed25519 public keys.
+	 */
+	public static function get_public_keys(): array {
+		$hex_keys = self::DEFAULT_PUBLIC_KEYS;
+
+		if ( defined( 'A8CSP_ATLANTIS_SNIPPET_PUBLIC_KEYS' ) && is_array( A8CSP_ATLANTIS_SNIPPET_PUBLIC_KEYS ) ) {
+			$hex_keys = array_merge( $hex_keys, A8CSP_ATLANTIS_SNIPPET_PUBLIC_KEYS );
+		}
+
+		$keys = array();
+		foreach ( array_unique( $hex_keys ) as $hex_key ) {
+			if ( ! is_string( $hex_key ) || '' === $hex_key ) {
+				continue;
+			}
+
+			try {
+				$raw = sodium_hex2bin( $hex_key );
+			} catch ( \SodiumException ) {
+				continue; // Malformed key; skip it rather than fatal.
+			}
+
+			if ( SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES === strlen( $raw ) ) {
+				$keys[] = $raw;
+			}
+		}
+
+		return $keys;
+	}
+
+	/**
+	 * Builds the canonical signed message for a snippet deployment.
+	 *
+	 * The content is bound via its sha256, so signing this short header is
+	 * equivalent to signing the code while keeping the message compact and
+	 * trivial to reproduce on the signer side.
+	 *
+	 * @param   string $snippet_id The stable snippet slug.
+	 * @param   int    $version    The monotonic version for this snippet id.
+	 * @param   string $sha256     Lowercase hex sha256 of the raw code bytes.
+	 * @param   string $expires    ISO-8601 expiry, or '' if the snippet never expires.
+	 *
+	 * @return  string
+	 */
+	public static function deploy_message( string $snippet_id, int $version, string $sha256, string $expires ): string {
+		return implode(
+			"\n",
+			array( 'a8csp-atlantis-snippet-deploy', 'v1', $snippet_id, (string) $version, $sha256, $expires )
+		);
+	}
+
+	/**
+	 * Builds the canonical signed message for a snippet removal.
+	 *
+	 * Removals are signed and version-bumped so an old deployment cannot be
+	 * replayed to "un-remove" a snippet.
+	 *
+	 * @param   string $snippet_id The stable snippet slug.
+	 * @param   int    $version    The monotonic version for this removal.
+	 *
+	 * @return  string
+	 */
+	public static function remove_message( string $snippet_id, int $version ): string {
+		return implode(
+			"\n",
+			array( 'a8csp-atlantis-snippet-remove', 'v1', $snippet_id, (string) $version )
+		);
+	}
+
+	/**
+	 * Verifies a base64-encoded detached signature against a message using any
+	 * of the accepted public keys.
+	 *
+	 * Fails closed: returns false if no keys are configured, the signature is
+	 * malformed, or none of the keys validate it.
+	 *
+	 * @param   string $message           The exact signed message.
+	 * @param   string $signature_base64  The detached signature, base64-encoded.
+	 *
+	 * @return  bool
+	 */
+	public static function verify( string $message, string $signature_base64 ): bool {
+		$signature = base64_decode( $signature_base64, true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		if ( false === $signature || SODIUM_CRYPTO_SIGN_BYTES !== strlen( $signature ) ) {
+			return false;
+		}
+
+		foreach ( self::get_public_keys() as $public_key ) {
+			if ( '' === $public_key ) {
+				continue;
+			}
+
+			try {
+				if ( sodium_crypto_sign_verify_detached( $signature, $message, $public_key ) ) {
+					return true;
+				}
+			} catch ( \SodiumException ) {
+				continue;
+			}
+		}
+
+		return false;
+	}
+
+	// endregion
+}

--- a/src/Modules/Snippets/SnippetStore.php
+++ b/src/Modules/Snippets/SnippetStore.php
@@ -1,0 +1,230 @@
+<?php declare( strict_types=1 );
+
+namespace A8C\SpecialProjects\Atlantis\Modules\Snippets;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Data-access layer for deployed snippets.
+ *
+ * Thin wrapper around the custom table (the on-site source of truth). All reads
+ * and writes to snippet state go through here.
+ *
+ * @since   1.3.0
+ * @version 1.3.0
+ */
+class SnippetStore {
+	// region READS
+
+	/**
+	 * Returns a single snippet row by its stable id, or null if not found.
+	 *
+	 * @param   string $snippet_id The stable snippet slug.
+	 *
+	 * @return  array<string, mixed>|null
+	 */
+	public function get( string $snippet_id ): ?array {
+		global $wpdb;
+
+		if ( ! CustomTable::table_exists() ) {
+			return null;
+		}
+
+		$table = CustomTable::get_table_name();
+		$row   = $wpdb->get_row(
+			$wpdb->prepare( "SELECT * FROM `$table` WHERE snippet_id = %s", $snippet_id ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			ARRAY_A
+		);
+
+		return is_array( $row ) ? $row : null;
+	}
+
+	/**
+	 * Returns all snippet rows, newest first.
+	 *
+	 * @return  array<int, array<string, mixed>>
+	 */
+	public function all(): array {
+		global $wpdb;
+
+		if ( ! CustomTable::table_exists() ) {
+			return array();
+		}
+
+		$table = CustomTable::get_table_name();
+		$rows  = $wpdb->get_results( "SELECT * FROM `$table` ORDER BY updated_at DESC", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return is_array( $rows ) ? $rows : array();
+	}
+
+	/**
+	 * Returns the rows that should currently be materialized and loaded:
+	 * status `active` and not past their expiry.
+	 *
+	 * @return  array<int, array<string, mixed>>
+	 */
+	public function all_loadable(): array {
+		global $wpdb;
+
+		if ( ! CustomTable::table_exists() ) {
+			return array();
+		}
+
+		$table = CustomTable::get_table_name();
+		$now   = current_time( 'mysql', true );
+		$rows  = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM `$table` WHERE status = 'active' AND ( expires_at IS NULL OR expires_at > %s ) ORDER BY snippet_id ASC", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$now
+			),
+			ARRAY_A
+		);
+
+		return is_array( $rows ) ? $rows : array();
+	}
+
+	// endregion
+
+	// region WRITES
+
+	/**
+	 * Inserts or updates a snippet, returning the stored row on success or a
+	 * WP_Error on a replayed/stale version or a database failure.
+	 *
+	 * @param   array<string, mixed> $data The snippet data: snippet_id (string),
+	 *                                     version (int), code (raw PHP bytes),
+	 *                                     sha256 (hex), signature (base64), notes
+	 *                                     (string|null), expires_at (UTC datetime|null).
+	 *
+	 * @return  array<string, mixed>|\WP_Error
+	 */
+	public function upsert( array $data ): array|\WP_Error {
+		global $wpdb;
+
+		$existing = $this->get( $data['snippet_id'] );
+		if ( is_array( $existing ) && (int) $existing['version'] >= (int) $data['version'] ) {
+			return new \WP_Error(
+				'a8csp_atlantis_snippet_stale_version',
+				sprintf(
+					/* translators: 1: incoming version, 2: stored version */
+					__( 'Refusing snippet: incoming version %1$d is not newer than stored version %2$d.', 'a8csp-atlantis' ),
+					(int) $data['version'],
+					(int) $existing['version']
+				)
+			);
+		}
+
+		$row = array(
+			'snippet_id' => $data['snippet_id'],
+			'version'    => (int) $data['version'],
+			'code'       => $data['code'],
+			'sha256'     => $data['sha256'],
+			'signature'  => $data['signature'],
+			'status'     => 'active',
+			'notes'      => $data['notes'] ?? null,
+			'fail_count' => 0,
+			'last_error' => null,
+			'expires_at' => $data['expires_at'] ?? null,
+		);
+
+		$formats = array( '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s' );
+
+		if ( is_array( $existing ) ) {
+			$result = $wpdb->update( CustomTable::get_table_name(), $row, array( 'snippet_id' => $data['snippet_id'] ), $formats, array( '%s' ) );
+		} else {
+			$result = $wpdb->insert( CustomTable::get_table_name(), $row, $formats );
+		}
+
+		if ( false === $result ) {
+			return new \WP_Error( 'a8csp_atlantis_snippet_db_error', __( 'Failed to persist the snippet.', 'a8csp-atlantis' ) );
+		}
+
+		$stored = $this->get( $data['snippet_id'] );
+		return is_array( $stored ) ? $stored : new \WP_Error( 'a8csp_atlantis_snippet_db_error', __( 'Snippet vanished after write.', 'a8csp-atlantis' ) );
+	}
+
+	/**
+	 * Sets a snippet's status (e.g. `removed`, `quarantined`, `expired`).
+	 *
+	 * @param   string $snippet_id The stable snippet slug.
+	 * @param   string $status     The new status.
+	 *
+	 * @return  bool
+	 */
+	public function set_status( string $snippet_id, string $status ): bool {
+		global $wpdb;
+
+		return false !== $wpdb->update(
+			CustomTable::get_table_name(),
+			array( 'status' => $status ),
+			array( 'snippet_id' => $snippet_id ),
+			array( '%s' ),
+			array( '%s' )
+		);
+	}
+
+	/**
+	 * Marks a snippet removed at (at least) the given version, bumping the stored
+	 * version so an older deploy cannot be replayed to bring it back.
+	 *
+	 * @param   string $snippet_id The stable snippet slug.
+	 * @param   int    $version    The removal version.
+	 *
+	 * @return  bool
+	 */
+	public function mark_removed( string $snippet_id, int $version ): bool {
+		global $wpdb;
+
+		return false !== $wpdb->update(
+			CustomTable::get_table_name(),
+			array(
+				'status'  => 'removed',
+				'version' => $version,
+			),
+			array( 'snippet_id' => $snippet_id ),
+			array( '%s', '%d' ),
+			array( '%s' )
+		);
+	}
+
+	/**
+	 * Records a runtime failure for a snippet: increments its fail counter and
+	 * stores the last error message.
+	 *
+	 * @param   string $snippet_id The stable snippet slug.
+	 * @param   string $error      The error message.
+	 *
+	 * @return  void
+	 */
+	public function record_failure( string $snippet_id, string $error ): void {
+		global $wpdb;
+
+		$table = CustomTable::get_table_name();
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE `$table` SET fail_count = fail_count + 1, last_error = %s WHERE snippet_id = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$error,
+				$snippet_id
+			)
+		);
+	}
+
+	/**
+	 * Permanently deletes a snippet row.
+	 *
+	 * @param   string $snippet_id The stable snippet slug.
+	 *
+	 * @return  bool
+	 */
+	public function delete( string $snippet_id ): bool {
+		global $wpdb;
+
+		return false !== $wpdb->delete(
+			CustomTable::get_table_name(),
+			array( 'snippet_id' => $snippet_id ),
+			array( '%s' )
+		);
+	}
+
+	// endregion
+}

--- a/src/Modules/Snippets/Snippets.php
+++ b/src/Modules/Snippets/Snippets.php
@@ -1,0 +1,133 @@
+<?php declare( strict_types=1 );
+
+namespace A8C\SpecialProjects\Atlantis\Modules\Snippets;
+
+use A8C\SpecialProjects\Atlantis\Modules\AbstractModule;
+use A8C\SpecialProjects\Atlantis\REST\Snippets_Controller;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Snippets module: fleet-wide remediation snippet runner.
+ *
+ * Lets a signed PHP remediation be deployed from OpsOasis / the team51 CLI to
+ * every managed site running Atlantis, without cutting a plugin release. Each
+ * deploy is pushed (never pulled), signature-verified, stored in the database
+ * (the on-site source of truth), and materialized as an mu-plugin that loads
+ * early and survives independently of Atlantis.
+ *
+ * This generalizes the hardcoded, release-gated core-compat filters in
+ * {@see \A8C\SpecialProjects\Atlantis\Plugin::register_core_compat_filters()}.
+ *
+ * See the bundled design doc (docs/snippet-runner-design.md) for the full trust
+ * model, threat analysis, and rollout protocol.
+ *
+ * @since   1.3.0
+ * @version 1.3.0
+ */
+class Snippets extends AbstractModule {
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * The custom table component.
+	 *
+	 * @var CustomTable
+	 */
+	private CustomTable $table;
+
+	/**
+	 * The snippet data store.
+	 *
+	 * @var SnippetStore
+	 */
+	private SnippetStore $store;
+
+	/**
+	 * The filesystem materializer / reconciler.
+	 *
+	 * @var Loader
+	 */
+	private Loader $loader;
+
+	/**
+	 * The REST receiver for pushed deployments.
+	 *
+	 * @var Snippets_Controller
+	 */
+	private Snippets_Controller $controller;
+
+	// endregion
+
+	// region MAGIC METHODS
+
+	/**
+	 * Constructor: wires the collaborators together.
+	 */
+	public function __construct() {
+		$this->table      = new CustomTable();
+		$this->store      = new SnippetStore();
+		$this->loader     = new Loader( $this->store );
+		$this->controller = new Snippets_Controller( $this->store, $this->loader );
+	}
+
+	// endregion
+
+	// region GETTERS
+
+	/**
+	 * Returns the module name.
+	 *
+	 * @return  string
+	 */
+	public function get_name(): string {
+		return __( 'Snippets', 'a8csp-atlantis' );
+	}
+
+	/**
+	 * Returns the module description.
+	 *
+	 * @return  string
+	 */
+	public function get_description(): string {
+		return __( 'Runs signed remediation snippets pushed from OpsOasis / the team51 CLI, so fleet-wide hotfixes can be deployed without a plugin release. Snippets are verified, stored, and loaded as must-use plugins.', 'a8csp-atlantis' );
+	}
+
+	/**
+	 * Exposes the snippet data store (for the WP-CLI command).
+	 *
+	 * @return  SnippetStore
+	 */
+	public function get_store(): SnippetStore {
+		return $this->store;
+	}
+
+	/**
+	 * Exposes the loader (for the WP-CLI command).
+	 *
+	 * @return  Loader
+	 */
+	public function get_loader(): Loader {
+		return $this->loader;
+	}
+
+	// endregion
+
+	// region METHODS
+
+	/**
+	 * Initializes the module components. Only runs when the module is active.
+	 *
+	 * @return  void
+	 */
+	protected function initialize(): void {
+		$this->table->initialize();
+
+		// Reconcile the filesystem to the database once the table is guaranteed
+		// to exist (CustomTable hooks `maybe_create_table` at the default priority).
+		add_action( 'init', array( $this->loader, 'reconcile' ), 20 );
+
+		$this->controller->initialize();
+	}
+
+	// endregion
+}

--- a/src/Modules/Snippets/index.php
+++ b/src/Modules/Snippets/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/src/Modules/Snippets/stubs/index.php
+++ b/src/Modules/Snippets/stubs/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/src/Modules/Snippets/stubs/snippets-loader.php
+++ b/src/Modules/Snippets/stubs/snippets-loader.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Plugin Name: Atlantis Snippet Loader
+ * Description: Loads remediation snippets deployed via Atlantis. Managed drop-in — do not edit; changes are overwritten by Atlantis.
+ * Version:     1.0.0
+ * Author:      Automattic Special Projects
+ *
+ * This file is a self-installed mu-plugin drop-in written by the Atlantis
+ * Snippets module. It loads *before* regular plugins so snippets can intercept
+ * hooks that would otherwise be registered too late, and it runs independently
+ * of Atlantis so remediations keep working even while Atlantis is mid-update.
+ *
+ * Every file it loads was signature-verified by Atlantis before being written,
+ * so this loader trusts the directory contents. Each snippet is required inside
+ * a try/catch so one bad snippet is skipped rather than fataling the whole site
+ * — the same resilience posture as the rest of the plugin.
+ *
+ * @package A8C\SpecialProjects\Atlantis
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'a8csp_atlantis_load_snippets' ) ) {
+	/**
+	 * Loads every materialized Atlantis snippet, isolating failures.
+	 *
+	 * @return void
+	 */
+	function a8csp_atlantis_load_snippets() {
+		$dir = __DIR__ . '/atlantis-snippets';
+
+		// Global kill switch: a single marker file disables all snippets at once.
+		if ( ! is_dir( $dir ) || file_exists( $dir . '/.disabled' ) ) {
+			return;
+		}
+
+		$snippets = glob( $dir . '/*.php' );
+		if ( false === $snippets ) {
+			return;
+		}
+
+		foreach ( $snippets as $snippet ) {
+			try {
+				require_once $snippet;
+			} catch ( \Throwable $throwable ) {
+				// Survive a broken snippet: log it and record the failure so Atlantis
+				// can auto-quarantine it, but never let it take down the request.
+				$snippet_id = basename( $snippet, '.php' );
+
+				error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					sprintf(
+						'[A8CSP Atlantis] Snippet "%s" failed to load: %s',
+						$snippet_id,
+						$throwable->getMessage()
+					)
+				);
+
+				if ( function_exists( 'a8csp_atlantis_record_snippet_failure' ) ) {
+					a8csp_atlantis_record_snippet_failure( $snippet_id, $throwable->getMessage() );
+				}
+			}
+		}
+	}
+}
+
+a8csp_atlantis_load_snippets();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -4,6 +4,7 @@ namespace A8C\SpecialProjects\Atlantis;
 
 use A8C\SpecialProjects\Atlantis\CLI\Message_Command;
 use A8C\SpecialProjects\Atlantis\CLI\Module_Command;
+use A8C\SpecialProjects\Atlantis\CLI\Snippet_Command;
 use A8C\SpecialProjects\Atlantis\REST\Status_Controller;
 
 defined( 'ABSPATH' ) || exit;
@@ -155,6 +156,7 @@ class Plugin {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			\WP_CLI::add_command( 'atlantis module', Module_Command::class );
 			\WP_CLI::add_command( 'atlantis message', Message_Command::class );
+			\WP_CLI::add_command( 'atlantis snippet', Snippet_Command::class );
 		}
 	}
 

--- a/src/REST/Snippets_Controller.php
+++ b/src/REST/Snippets_Controller.php
@@ -1,0 +1,333 @@
+<?php declare( strict_types=1 );
+
+namespace A8C\SpecialProjects\Atlantis\REST;
+
+use A8C\SpecialProjects\Atlantis\Modules\Snippets\Loader;
+use A8C\SpecialProjects\Atlantis\Modules\Snippets\Signature;
+use A8C\SpecialProjects\Atlantis\Modules\Snippets\SnippetStore;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST receiver for pushed snippet deployments.
+ *
+ * OpsOasis (fanning out over the managed fleet with the blog/partner token)
+ * deposits signed snippets here; the site never pulls. Two independent gates
+ * protect execution:
+ *
+ *  1. the permission check — only site admins / Jetpack-tunneled WPCOM partner
+ *     calls may reach the route at all; and
+ *  2. the Ed25519 signature — even a fully authenticated caller cannot make a
+ *     site store or remove a snippet without OpsOasis's offline private key.
+ *
+ * @since   1.3.0
+ * @version 1.3.0
+ */
+class Snippets_Controller {
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * REST namespace.
+	 *
+	 * @var string
+	 */
+	private string $namespace = 'a8csp-atlantis/v1';
+
+	/**
+	 * REST base for this controller.
+	 *
+	 * @var string
+	 */
+	private string $rest_base = 'snippets';
+
+	/**
+	 * The snippet data store.
+	 *
+	 * @var SnippetStore
+	 */
+	private SnippetStore $store;
+
+	/**
+	 * The filesystem materializer / reconciler.
+	 *
+	 * @var Loader
+	 */
+	private Loader $loader;
+
+	// endregion
+
+	// region MAGIC METHODS
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   SnippetStore $store  The snippet data store.
+	 * @param   Loader       $loader The filesystem materializer / reconciler.
+	 */
+	public function __construct( SnippetStore $store, Loader $loader ) {
+		$this->store  = $store;
+		$this->loader = $loader;
+	}
+
+	// endregion
+
+	// region METHODS
+
+	/**
+	 * Registers the controller hooks.
+	 *
+	 * @return void
+	 */
+	public function initialize(): void {
+		\add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Registers the REST routes for this controller.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		\register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'callback'            => array( $this, 'list_items' ),
+				),
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'callback'            => array( $this, 'deploy_item' ),
+				),
+			)
+		);
+
+		// Removal accepts POST as well as DELETE: the OpsOasis fan-out proxies over
+		// WPCOM's Jetpack tunnel, which only forwards a request body for editable
+		// (POST/PUT/PATCH) methods, and the signed removal payload travels in the body.
+		\register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<snippet_id>[a-z0-9][a-z0-9_-]*)',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE . ', ' . \WP_REST_Server::DELETABLE,
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'callback'            => array( $this, 'remove_item' ),
+				),
+			)
+		);
+	}
+
+	// endregion
+
+	// region CALLBACKS
+
+	/**
+	 * Permission check: only site admins (or equivalents authenticated via
+	 * Jetpack-tunneled WPCOM calls) may reach the snippet routes. The signature
+	 * check in the handlers is the gate that actually authorizes execution.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @param \WP_REST_Request $request The REST request (unused).
+	 *
+	 * @return true|\WP_Error
+	 */
+	public function permissions_check( \WP_REST_Request $request ): true|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		if ( ! \current_user_can( 'manage_options' ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				\__( 'You do not have permission to manage Atlantis snippets.', 'a8csp-atlantis' ),
+				array( 'status' => \rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Stores a pushed, signed snippet and materializes it immediately.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @param \WP_REST_Request $request The REST request.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function deploy_item( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
+		$snippet_id = (string) $request->get_param( 'snippet_id' );
+		$version    = (int) $request->get_param( 'version' );
+		$code_b64   = (string) $request->get_param( 'code' );
+		$sha256     = strtolower( (string) $request->get_param( 'sha256' ) );
+		$signature  = (string) $request->get_param( 'signature' );
+		$expires    = (string) ( $request->get_param( 'expires' ) ?? '' );
+		$notes      = $request->get_param( 'notes' );
+
+		if ( ! $this->is_valid_id( $snippet_id ) ) {
+			return new \WP_Error( 'a8csp_atlantis_snippet_invalid_id', \__( 'Invalid snippet id.', 'a8csp-atlantis' ), array( 'status' => 400 ) );
+		}
+
+		if ( $version < 1 ) {
+			return new \WP_Error( 'a8csp_atlantis_snippet_invalid_version', \__( 'A positive integer version is required.', 'a8csp-atlantis' ), array( 'status' => 400 ) );
+		}
+
+		$code = base64_decode( $code_b64, true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		if ( false === $code || '' === $code ) {
+			return new \WP_Error( 'a8csp_atlantis_snippet_bad_encoding', \__( 'Snippet code is not valid base64.', 'a8csp-atlantis' ), array( 'status' => 400 ) );
+		}
+
+		if ( ! hash_equals( hash( 'sha256', $code ), $sha256 ) ) {
+			return new \WP_Error( 'a8csp_atlantis_snippet_hash_mismatch', \__( 'Snippet hash does not match its code.', 'a8csp-atlantis' ), array( 'status' => 400 ) );
+		}
+
+		$message = Signature::deploy_message( $snippet_id, $version, $sha256, $expires );
+		if ( ! Signature::verify( $message, $signature ) ) {
+			return new \WP_Error( 'a8csp_atlantis_snippet_bad_signature', \__( 'Snippet signature verification failed.', 'a8csp-atlantis' ), array( 'status' => 403 ) );
+		}
+
+		$stored = $this->store->upsert(
+			array(
+				'snippet_id' => $snippet_id,
+				'version'    => $version,
+				'code'       => $code,
+				'sha256'     => $sha256,
+				'signature'  => $signature,
+				'notes'      => is_string( $notes ) ? $notes : null,
+				'expires_at' => $this->normalize_expiry( $expires ),
+			)
+		);
+
+		if ( \is_wp_error( $stored ) ) {
+			$stored->add_data( array( 'status' => 409 ) );
+			return $stored;
+		}
+
+		$this->loader->reconcile();
+
+		return \rest_ensure_response(
+			array(
+				'stored'     => true,
+				'snippet_id' => $snippet_id,
+				'version'    => $version,
+				'sha256'     => $sha256,
+				'applied'    => $this->loader->can_materialize(),
+			)
+		);
+	}
+
+	/**
+	 * Marks a snippet removed (signed removal) and clears its materialized file.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @param \WP_REST_Request $request The REST request.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function remove_item( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
+		$snippet_id = (string) $request->get_param( 'snippet_id' );
+		$version    = (int) $request->get_param( 'version' );
+		$signature  = (string) $request->get_param( 'signature' );
+
+		if ( ! $this->is_valid_id( $snippet_id ) ) {
+			return new \WP_Error( 'a8csp_atlantis_snippet_invalid_id', \__( 'Invalid snippet id.', 'a8csp-atlantis' ), array( 'status' => 400 ) );
+		}
+
+		$existing = $this->store->get( $snippet_id );
+		if ( null === $existing ) {
+			return new \WP_Error( 'a8csp_atlantis_snippet_not_found', \__( 'Snippet not found.', 'a8csp-atlantis' ), array( 'status' => 404 ) );
+		}
+
+		if ( $version <= (int) $existing['version'] ) {
+			return new \WP_Error( 'a8csp_atlantis_snippet_stale_version', \__( 'Removal version must be newer than the stored version.', 'a8csp-atlantis' ), array( 'status' => 409 ) );
+		}
+
+		$message = Signature::remove_message( $snippet_id, $version );
+		if ( ! Signature::verify( $message, $signature ) ) {
+			return new \WP_Error( 'a8csp_atlantis_snippet_bad_signature', \__( 'Snippet removal signature verification failed.', 'a8csp-atlantis' ), array( 'status' => 403 ) );
+		}
+
+		$this->store->mark_removed( $snippet_id, $version );
+		$this->loader->reconcile();
+
+		return \rest_ensure_response(
+			array(
+				'removed'    => true,
+				'snippet_id' => $snippet_id,
+				'version'    => $version,
+			)
+		);
+	}
+
+	/**
+	 * Returns the current snippet inventory for fleet status reporting.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @param \WP_REST_Request $request The REST request (unused).
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function list_items( \WP_REST_Request $request ): \WP_REST_Response { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		$items = array();
+
+		foreach ( $this->store->all() as $row ) {
+			$items[] = array(
+				'snippet_id' => $row['snippet_id'],
+				'version'    => (int) $row['version'],
+				'status'     => $row['status'],
+				'sha256'     => $row['sha256'],
+				'fail_count' => (int) $row['fail_count'],
+				'expires_at' => $row['expires_at'],
+				'updated_at' => $row['updated_at'],
+			);
+		}
+
+		return \rest_ensure_response(
+			array(
+				'can_materialize' => $this->loader->can_materialize(),
+				'snippets'        => $items,
+			)
+		);
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Validates a snippet id (lowercase slug).
+	 *
+	 * @param   string $snippet_id The candidate id.
+	 *
+	 * @return  bool
+	 */
+	private function is_valid_id( string $snippet_id ): bool {
+		return 1 === preg_match( '/^[a-z0-9][a-z0-9_-]{0,190}$/', $snippet_id );
+	}
+
+	/**
+	 * Normalizes an ISO-8601 expiry into a MySQL UTC datetime, or null.
+	 *
+	 * @param   string $expires The ISO-8601 expiry, or ''.
+	 *
+	 * @return  string|null
+	 */
+	private function normalize_expiry( string $expires ): ?string {
+		if ( '' === $expires ) {
+			return null;
+		}
+
+		$timestamp = strtotime( $expires );
+		if ( false === $timestamp ) {
+			return null;
+		}
+
+		return gmdate( 'Y-m-d H:i:s', $timestamp );
+	}
+
+	// endregion
+}


### PR DESCRIPTION
## Summary

Adds a **Snippets** module to Atlantis: a way to run **signed PHP remediation snippets** pushed from OpsOasis / the team51 CLI, so fleet-wide hotfixes (a core/Gutenberg/WooCommerce regression, etc.) can be deployed **without cutting a plugin release**. It generalizes the hardcoded, release-gated pattern in `Plugin::register_core_compat_filters()` (the `wp_img_tag_add_auto_sizes` mitigation).

📄 **Full design doc, trust model, threat analysis, and signing spec:** [`docs/snippet-runner-design.md`](docs/snippet-runner-design.md) — please read this first.

## How it works

- **Push-only, signed.** OpsOasis holds the Ed25519 **private** key and signs each snippet; Atlantis ships a **verify-only public** key and refuses anything it can't verify. Sites never pull, so a random public install of this plugin is never a target and snippet code is never served to it.
- **DB is the on-site source of truth.** A pushed snippet is stored in `wp_a8csp_atlantis_snippets`, then **materialized** as an early-loading mu-plugin drop-in. The filesystem is **reconciled to the DB on `init`**, so snippets self-heal across code deploys / filesystem resets.
- **Resilient.** Each snippet loads inside `try/catch(\Throwable)` (same posture as `f543e18`), auto-quarantines after repeated fatals, honors an expiry, and a **global kill switch** disables everything at once.

## What's here

- `src/Modules/Snippets/` — `CustomTable`, `SnippetStore`, `Signature`, `Loader`, `DropIn`, `Snippets`, `stubs/snippets-loader.php`
- `src/REST/Snippets_Controller.php` — receiver (deploy / remove / list)
- `src/CLI/Snippet_Command.php` — `wp atlantis snippet list|show|verify|remove|flush|reconcile|disable|enable`
- wired into `Modules.php` + `Plugin.php`; helpers in `includes/module-snippets.php`

## Before this works end-to-end

1. **Provision the keypair** — `Signature::DEFAULT_PUBLIC_KEYS` is intentionally **empty** (fail-closed: nothing is deployable) until the real public key is baked in and the private key is stored on OpsOasis. Runbook in design doc §14.4.
2. Companion PRs (whole feature spans three repos):
   - OpsOasis: `a8cteam51/opsoasis` `add/fleet-snippet-runner`
   - CLI: `a8cteam51/team51-cli` `add/fleet-snippet-runner`

## Status

Draft for team review. phpcs / phpstan / phpmd clean. Lint-and-design review requested before any merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
