### PR TITLE
add: WP Cloud Bot Protection module (1.3.0, T51ENG-1996)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This file provides AI coding assistants with the context they need to work effec
 - Auto-update control (timing windows, rollout delays, centralized settings, per-plugin filter toggles).
 - Tracking integrations (WooCommerce, Sensei, Bilmur).
 - Colophon utilities (credits action + shortcodes).
+- WP Cloud Bot Protection control (per-site enforcement of the `wpcloud_bot_protection_enable` filter).
 
 **Text domain:** `a8csp-atlantis`  
 **Namespace:** `A8C\SpecialProjects\Atlantis\`  
@@ -55,6 +56,7 @@ a8csp-atlantis/
 │       ├── AbstractModule.php    ← Module lifecycle/settings base class
 │       ├── Messages/
 │       ├── Autoupdates/
+│       ├── BotProtection/
 │       ├── Tracking/
 │       └── Colophon/
 │

--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ but does not *enable* — `off` is the dependable lever, while `on` only forces 
 where a tier (the constant or the client rollout) has already armed the loader.
 See `src/Modules/BotProtection/README.md` for the full matrix.
 
+On non-production environments (`wp_get_environment_type()` other than
+`production`), protection is forced off unless `state` is explicitly `on`, so
+staging/dev sites that run login automation aren't gated — mirroring the
+Tracking module's production gating.
+
 More detail: `src/Modules/BotProtection/README.md`.
 
 ## Runtime Interfaces

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Plugin metadata from `a8csp-atlantis.php`:
 - `functions.php` loads global helper wrappers from `includes/`.
 - `src/` contains the PSR-4 plugin classes, module registry, settings UI,
   encryption component, REST controller, and WP-CLI commands.
-- `src/Modules/` contains the Messages, Autoupdates, Tracking, and Colophon
-  modules. Each module has a nested README with more detailed behavior notes.
+- `src/Modules/` contains the Messages, Autoupdates, Tracking, Colophon, and Bot
+  Protection modules. Each module has a nested README with more detailed
+  behavior notes.
 - `models/` contains the DB-backed message model and query/list-table support.
 - `templates/` contains admin templates, including the message form.
 - `assets/js/src/` and `assets/css/src/` are the editable JS and SCSS sources.
@@ -96,6 +97,24 @@ standard footer credits. Output links can be adjusted with the
 
 More detail: `src/Modules/Colophon/README.md`.
 
+### Bot Protection
+
+The Bot Protection module is the control plane for WP Cloud Bot Protection (the
+external name for "blackbox") — login and password-reset gating shipped as the
+`wpcloud-bot-protection` mu-plugin on WP Cloud sites. The module drives the
+mu-plugin's `wpcloud_bot_protection_enable` filter from a single mandatory
+`state` setting:
+
+- `inherit` (default) registers nothing and leaves WP Cloud's own tiers to
+  decide, so shipping the module changes no behavior.
+- `on` forces protection enabled.
+- `off` forces protection disabled — a hard override even against a client-level
+  rollout.
+
+The setting is a no-op on non-WP-Cloud sites and where the mu-plugin is absent.
+
+More detail: `src/Modules/BotProtection/README.md`.
+
 ## Runtime Interfaces
 
 Atlantis registers an `Atlantis` wp-admin menu for users who pass
@@ -120,6 +139,8 @@ wp atlantis module activate <key>...
 wp atlantis module deactivate <key>...
 wp atlantis message list
 wp atlantis message get <id>
+wp atlantis bot-protection status
+wp atlantis bot-protection set <inherit|on|off>
 ```
 
 ## Development Requirements

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ wp atlantis module activate <key>...
 wp atlantis module deactivate <key>...
 wp atlantis message list
 wp atlantis message get <id>
-wp atlantis bot-protection status
-wp atlantis bot-protection set <inherit|off>
+wp atlantis module bot-protection status
+wp atlantis module bot-protection set <inherit|off>
 ```
 
 ## Development Requirements

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Plugin metadata from `a8csp-atlantis.php`:
 
 - Plugin name: `A8CSP Atlantis`
 - Text domain: `a8csp-atlantis`
-- Version: `1.4.0`
+- Version: `1.3.0`
 - Requires WordPress: `6.8+`
 - Tested up to WordPress: `7.0`
 - Requires PHP: `8.2+`

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ mu-plugin's `wpcloud_bot_protection_enable` filter from a single mandatory
   rollout.
 
 The setting is a no-op on non-WP-Cloud sites and where the mu-plugin is absent.
+Note: in the currently deployed WP Cloud loader the filter reliably *disables*
+but does not *enable* — `off` is the dependable lever, while `on` only forces on
+where a tier (the constant or the client rollout) has already armed the loader.
+See `src/Modules/BotProtection/README.md` for the full matrix.
 
 More detail: `src/Modules/BotProtection/README.md`.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Plugin metadata from `a8csp-atlantis.php`:
 
 - Plugin name: `A8CSP Atlantis`
 - Text domain: `a8csp-atlantis`
-- Version: `1.2.4`
+- Version: `1.4.0`
 - Requires WordPress: `6.8+`
 - Tested up to WordPress: `7.0`
 - Requires PHP: `8.2+`

--- a/README.md
+++ b/README.md
@@ -117,10 +117,9 @@ indistinguishable from `inherit`. To enable a site, arm a tier — set
 percentage rollout. The `off` setting is a no-op on non-WP-Cloud sites and where
 the mu-plugin is absent.
 
-On non-production environments (`wp_get_environment_type()` other than
-`production`), protection is forced off regardless of `state`, so staging/dev
-sites that run login automation aren't gated — mirroring the Tracking module's
-production gating.
+The `state` applies uniformly across environments — staging/dev sites `inherit`
+by default like production. A non-production site that runs login automation and
+must stay clear is set to `off` explicitly.
 
 More detail: `src/Modules/BotProtection/README.md`.
 

--- a/README.md
+++ b/README.md
@@ -107,20 +107,20 @@ mu-plugin's `wpcloud_bot_protection_enable` filter from a single mandatory
 
 - `inherit` (default) registers nothing and leaves WP Cloud's own tiers to
   decide, so shipping the module changes no behavior.
-- `on` forces protection enabled.
 - `off` forces protection disabled — a hard override even against a client-level
   rollout.
 
-The setting is a no-op on non-WP-Cloud sites and where the mu-plugin is absent.
-Note: in the currently deployed WP Cloud loader the filter reliably *disables*
-but does not *enable* — `off` is the dependable lever, while `on` only forces on
-where a tier (the constant or the client rollout) has already armed the loader.
-See `src/Modules/BotProtection/README.md` for the full matrix.
+There is deliberately no `on`: in the currently deployed WP Cloud loader the
+filter reliably *disables* but does not *enable*, so an `on` would be
+indistinguishable from `inherit`. To enable a site, arm a tier — set
+`WPC_BOT_PROTECTION_ENABLED = true` or have the client enabled via the platform
+percentage rollout. The `off` setting is a no-op on non-WP-Cloud sites and where
+the mu-plugin is absent.
 
 On non-production environments (`wp_get_environment_type()` other than
-`production`), protection is forced off unless `state` is explicitly `on`, so
-staging/dev sites that run login automation aren't gated — mirroring the
-Tracking module's production gating.
+`production`), protection is forced off regardless of `state`, so staging/dev
+sites that run login automation aren't gated — mirroring the Tracking module's
+production gating.
 
 More detail: `src/Modules/BotProtection/README.md`.
 
@@ -149,7 +149,7 @@ wp atlantis module deactivate <key>...
 wp atlantis message list
 wp atlantis message get <id>
 wp atlantis bot-protection status
-wp atlantis bot-protection set <inherit|on|off>
+wp atlantis bot-protection set <inherit|off>
 ```
 
 ## Development Requirements

--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -3,7 +3,7 @@
  * The A8CSP Atlantis bootstrap file.
  *
  * @since       1.0.0
- * @version     1.2.4
+ * @version     1.4.0
  * @package     A8C\SpecialProjects\Plugins
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
@@ -15,7 +15,7 @@
  * Plugin URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Update URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Description:             Centralized site management for Team51.
- * Version:                 1.2.4
+ * Version:                 1.4.0
  * Requires at least:       6.8
  * Tested up to:            7.0
  * Requires PHP:            8.2

--- a/a8csp-atlantis.php
+++ b/a8csp-atlantis.php
@@ -3,7 +3,7 @@
  * The A8CSP Atlantis bootstrap file.
  *
  * @since       1.0.0
- * @version     1.4.0
+ * @version     1.3.0
  * @package     A8C\SpecialProjects\Plugins
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
@@ -15,7 +15,7 @@
  * Plugin URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Update URI:              https://github.com/a8cteam51/a8csp-atlantis
  * Description:             Centralized site management for Team51.
- * Version:                 1.4.0
+ * Version:                 1.3.0
  * Requires at least:       6.8
  * Tested up to:            7.0
  * Requires PHP:            8.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a8csp-atlantis",
-  "version": "1.4.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a8csp-atlantis",
-      "version": "1.4.0",
+      "version": "1.3.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "select2": "^4.1.0-rc.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a8csp-atlantis",
-  "version": "1.2.4",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a8csp-atlantis",
-      "version": "1.2.4",
+      "version": "1.4.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "select2": "^4.1.0-rc.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a8csp-atlantis",
-  "version": "1.2.4",
+  "version": "1.4.0",
   "description": "A scaffold for A8C Special Projects plugins",
   "author": {
     "name": "A8C Special Projects Team",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a8csp-atlantis",
-  "version": "1.4.0",
+  "version": "1.3.0",
   "description": "A scaffold for A8C Special Projects plugins",
   "author": {
     "name": "A8C Special Projects Team",

--- a/src/CLI/BotProtection_Command.php
+++ b/src/CLI/BotProtection_Command.php
@@ -94,6 +94,10 @@ class BotProtection_Command {
 		$formatter->display_items( array( $row ) );
 	}
 
+	// The `<state>` options list below quotes "off" on purpose: WP-CLI parses the
+	// `---` synopsis block as YAML, where the bare word `off` coerces to boolean
+	// false (the YAML "Norway problem"), leaving the allowed list as
+	// [ 'inherit', false ] so `set off` fails synopsis validation. Do not unquote.
 	/**
 	 * Sets the bot protection enforcement state.
 	 *
@@ -110,7 +114,7 @@ class BotProtection_Command {
 	 * ---
 	 * options:
 	 *   - inherit
-	 *   - off
+	 *   - "off"
 	 * ---
 	 *
 	 * ## EXAMPLES

--- a/src/CLI/BotProtection_Command.php
+++ b/src/CLI/BotProtection_Command.php
@@ -21,8 +21,8 @@ defined( 'ABSPATH' ) || exit;
  *     $ wp atlantis module bot-protection set off
  *     $ wp atlantis module bot-protection set inherit
  *
- * @since   1.4.0
- * @version 1.4.0
+ * @since   1.3.0
+ * @version 1.3.0
  */
 class BotProtection_Command {
 	/**

--- a/src/CLI/BotProtection_Command.php
+++ b/src/CLI/BotProtection_Command.php
@@ -12,14 +12,14 @@ defined( 'ABSPATH' ) || exit;
  * ## EXAMPLES
  *
  *     # Show the current enforcement state and WP Cloud context.
- *     $ wp atlantis bot-protection status
+ *     $ wp atlantis module bot-protection status
  *
  *     # Output just the state (for scripting).
- *     $ wp atlantis bot-protection status --field=state
+ *     $ wp atlantis module bot-protection status --field=state
  *
  *     # Force bot protection off on a site, or defer to WP Cloud's default.
- *     $ wp atlantis bot-protection set off
- *     $ wp atlantis bot-protection set inherit
+ *     $ wp atlantis module bot-protection set off
+ *     $ wp atlantis module bot-protection set inherit
  *
  * @since   1.4.0
  * @version 1.4.0
@@ -68,9 +68,9 @@ class BotProtection_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     $ wp atlantis bot-protection status
-	 *     $ wp atlantis bot-protection status --field=state
-	 *     $ wp atlantis bot-protection status --format=json
+	 *     $ wp atlantis module bot-protection status
+	 *     $ wp atlantis module bot-protection status --field=state
+	 *     $ wp atlantis module bot-protection status --format=json
 	 *
 	 * @param array<int, string>         $args       Positional args (unused).
 	 * @param array<string, string|bool> $assoc_args Flags.
@@ -115,8 +115,8 @@ class BotProtection_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     $ wp atlantis bot-protection set off
-	 *     $ wp atlantis bot-protection set inherit
+	 *     $ wp atlantis module bot-protection set off
+	 *     $ wp atlantis module bot-protection set inherit
 	 *
 	 * @param array<int, string>         $args       Positional args: <state>.
 	 * @param array<string, string|bool> $assoc_args Flags (unused).

--- a/src/CLI/BotProtection_Command.php
+++ b/src/CLI/BotProtection_Command.php
@@ -83,7 +83,7 @@ class BotProtection_Command {
 			'state'             => BotProtection::get_configured_state(),
 			'wp_cloud'          => BotProtection::is_wp_cloud(),
 			'mu_plugin_present' => BotProtection::is_mu_plugin_present(),
-			'environment'       => \function_exists( 'wp_get_environment_type' ) ? \wp_get_environment_type() : 'production',
+			'environment'       => \wp_get_environment_type(),
 		);
 
 		$fields = isset( $assoc_args['fields'] )

--- a/src/CLI/BotProtection_Command.php
+++ b/src/CLI/BotProtection_Command.php
@@ -31,7 +31,7 @@ class BotProtection_Command {
 	 *
 	 * @var array<int, string>
 	 */
-	private const DEFAULT_FIELDS = array( 'state', 'wp_cloud', 'mu_plugin_present' );
+	private const DEFAULT_FIELDS = array( 'state', 'wp_cloud', 'mu_plugin_present', 'environment' );
 
 	// region SUBCOMMANDS
 
@@ -46,7 +46,7 @@ class BotProtection_Command {
 	 * [--fields=<fields>]
 	 * : Comma-separated list of fields to show.
 	 * ---
-	 * default: state,wp_cloud,mu_plugin_present
+	 * default: state,wp_cloud,mu_plugin_present,environment
 	 * ---
 	 *
 	 * [--format=<format>]
@@ -65,6 +65,7 @@ class BotProtection_Command {
 	 * * state             - Enforcement state: inherit, on, or off.
 	 * * wp_cloud          - Whether WP Cloud credentials (ATOMIC_SITE_ID / ATOMIC_SITE_API_KEY) are present.
 	 * * mu_plugin_present - Whether the wpcloud-bot-protection mu-plugin is loaded.
+	 * * environment       - The site's environment type; non-production forces protection off unless state is `on`.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -83,6 +84,7 @@ class BotProtection_Command {
 			'state'             => BotProtection::get_configured_state(),
 			'wp_cloud'          => BotProtection::is_wp_cloud(),
 			'mu_plugin_present' => BotProtection::is_mu_plugin_present(),
+			'environment'       => \function_exists( 'wp_get_environment_type' ) ? \wp_get_environment_type() : 'production',
 		);
 
 		$fields = isset( $assoc_args['fields'] )

--- a/src/CLI/BotProtection_Command.php
+++ b/src/CLI/BotProtection_Command.php
@@ -17,8 +17,7 @@ defined( 'ABSPATH' ) || exit;
  *     # Output just the state (for scripting).
  *     $ wp atlantis bot-protection status --field=state
  *
- *     # Force bot protection on / off, or defer to WP Cloud's default.
- *     $ wp atlantis bot-protection set on
+ *     # Force bot protection off on a site, or defer to WP Cloud's default.
  *     $ wp atlantis bot-protection set off
  *     $ wp atlantis bot-protection set inherit
  *
@@ -62,7 +61,7 @@ class BotProtection_Command {
 	 *
 	 * ## AVAILABLE FIELDS
 	 *
-	 * * state             - Enforcement state: inherit, on, or off.
+	 * * state             - Enforcement state: inherit or off.
 	 * * wp_cloud          - Whether WP Cloud credentials (ATOMIC_SITE_ID / ATOMIC_SITE_API_KEY) are present.
 	 * * mu_plugin_present - Whether the wpcloud-bot-protection mu-plugin is loaded.
 	 * * environment       - The site's environment type; non-production forces protection off unless state is `on`.
@@ -98,9 +97,11 @@ class BotProtection_Command {
 	/**
 	 * Sets the bot protection enforcement state.
 	 *
-	 * `inherit` leaves WP Cloud's own enablement tiers untouched; `on` and `off`
-	 * force the state via the `wpcloud_bot_protection_enable` filter, overriding
-	 * every other tier (including any client-level percentage rollout).
+	 * `inherit` leaves WP Cloud's own enablement tiers untouched; `off` forces
+	 * protection disabled via the `wpcloud_bot_protection_enable` filter,
+	 * overriding every other tier (including any client-level percentage
+	 * rollout). There is no `on`: the filter cannot enable a site that no tier
+	 * has armed — enable via the constant or a client-level rollout instead.
 	 *
 	 * ## OPTIONS
 	 *
@@ -109,13 +110,11 @@ class BotProtection_Command {
 	 * ---
 	 * options:
 	 *   - inherit
-	 *   - on
 	 *   - off
 	 * ---
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     $ wp atlantis bot-protection set on
 	 *     $ wp atlantis bot-protection set off
 	 *     $ wp atlantis bot-protection set inherit
 	 *
@@ -142,15 +141,15 @@ class BotProtection_Command {
 	// region HELPERS
 
 	/**
-	 * Warns that a force on/off has no effect when the site is not WP Cloud.
+	 * Warns that a force-off has no effect when the site is not WP Cloud or the
+	 * mu-plugin is absent.
 	 *
 	 * @param string $state The enforcement state that was requested.
 	 *
 	 * @return void
 	 */
 	private function maybe_warn_no_effect( string $state ): void {
-		$forces = \in_array( $state, array( BotProtection::STATE_ON, BotProtection::STATE_OFF ), true );
-		if ( ! $forces ) {
+		if ( BotProtection::STATE_OFF !== $state ) {
 			return;
 		}
 

--- a/src/CLI/BotProtection_Command.php
+++ b/src/CLI/BotProtection_Command.php
@@ -76,10 +76,13 @@ class BotProtection_Command {
 	 * @param array<string, string|bool> $assoc_args Flags.
 	 */
 	public function status( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		// Booleans (not yes/no strings) to match the /status REST payload and the
+		// `mandatory` field of `wp atlantis module`, so a fleet consumer reading
+		// either surface gets the same types.
 		$row = array(
 			'state'             => BotProtection::get_configured_state(),
-			'wp_cloud'          => BotProtection::is_wp_cloud() ? 'yes' : 'no',
-			'mu_plugin_present' => BotProtection::is_mu_plugin_present() ? 'yes' : 'no',
+			'wp_cloud'          => BotProtection::is_wp_cloud(),
+			'mu_plugin_present' => BotProtection::is_mu_plugin_present(),
 		);
 
 		$fields = isset( $assoc_args['fields'] )
@@ -120,12 +123,9 @@ class BotProtection_Command {
 	public function set( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$state = (string) ( $args[0] ?? '' );
 
-		if ( BotProtection::get_configured_state() === $state ) {
-			\WP_CLI::log( \sprintf( "Bot protection enforcement is already '%s'; no change.", $state ) );
-			$this->maybe_warn_no_effect( $state );
-			return;
-		}
-
+		// Always persist rather than short-circuit on the normalized current
+		// state: a bogus stored value reads as `inherit`, so a `set inherit`
+		// must still rewrite it to a clean value.
 		$result = BotProtection::set_state( $state );
 		if ( \is_wp_error( $result ) ) {
 			\WP_CLI::error( $result->get_error_message() );
@@ -148,8 +148,14 @@ class BotProtection_Command {
 	 */
 	private function maybe_warn_no_effect( string $state ): void {
 		$forces = \in_array( $state, array( BotProtection::STATE_ON, BotProtection::STATE_OFF ), true );
-		if ( $forces && ! BotProtection::is_wp_cloud() ) {
+		if ( ! $forces ) {
+			return;
+		}
+
+		if ( ! BotProtection::is_wp_cloud() ) {
 			\WP_CLI::warning( 'This site is not a WP Cloud site, so this setting has no effect here.' );
+		} elseif ( ! BotProtection::is_mu_plugin_present() ) {
+			\WP_CLI::warning( 'The WP Cloud bot protection mu-plugin is not present on this site, so this setting has no effect here.' );
 		}
 	}
 

--- a/src/CLI/BotProtection_Command.php
+++ b/src/CLI/BotProtection_Command.php
@@ -64,7 +64,7 @@ class BotProtection_Command {
 	 * * state             - Enforcement state: inherit or off.
 	 * * wp_cloud          - Whether WP Cloud credentials (ATOMIC_SITE_ID / ATOMIC_SITE_API_KEY) are present.
 	 * * mu_plugin_present - Whether the wpcloud-bot-protection mu-plugin is loaded.
-	 * * environment       - The site's environment type; non-production forces protection off unless state is `on`.
+	 * * environment       - The site's environment type (informational; enforcement is driven by state).
 	 *
 	 * ## EXAMPLES
 	 *

--- a/src/CLI/BotProtection_Command.php
+++ b/src/CLI/BotProtection_Command.php
@@ -1,0 +1,157 @@
+<?php declare( strict_types=1 );
+
+namespace A8C\SpecialProjects\Atlantis\CLI;
+
+use A8C\SpecialProjects\Atlantis\Modules\BotProtection\BotProtection;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manage WP Cloud Bot Protection from the command line.
+ *
+ * ## EXAMPLES
+ *
+ *     # Show the current enforcement state and WP Cloud context.
+ *     $ wp atlantis bot-protection status
+ *
+ *     # Output just the state (for scripting).
+ *     $ wp atlantis bot-protection status --field=state
+ *
+ *     # Force bot protection on / off, or defer to WP Cloud's default.
+ *     $ wp atlantis bot-protection set on
+ *     $ wp atlantis bot-protection set off
+ *     $ wp atlantis bot-protection set inherit
+ *
+ * @since   1.4.0
+ * @version 1.4.0
+ */
+class BotProtection_Command {
+	/**
+	 * Default fields returned by `status`.
+	 *
+	 * @var array<int, string>
+	 */
+	private const DEFAULT_FIELDS = array( 'state', 'wp_cloud', 'mu_plugin_present' );
+
+	// region SUBCOMMANDS
+
+	/**
+	 * Shows the current bot protection enforcement state and WP Cloud context.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--field=<field>]
+	 * : Output just this field's value.
+	 *
+	 * [--fields=<fields>]
+	 * : Comma-separated list of fields to show.
+	 * ---
+	 * default: state,wp_cloud,mu_plugin_present
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Render output in the given format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 * ---
+	 *
+	 * ## AVAILABLE FIELDS
+	 *
+	 * * state             - Enforcement state: inherit, on, or off.
+	 * * wp_cloud          - Whether WP Cloud credentials (ATOMIC_SITE_ID / ATOMIC_SITE_API_KEY) are present.
+	 * * mu_plugin_present - Whether the wpcloud-bot-protection mu-plugin is loaded.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp atlantis bot-protection status
+	 *     $ wp atlantis bot-protection status --field=state
+	 *     $ wp atlantis bot-protection status --format=json
+	 *
+	 * @param array<int, string>         $args       Positional args (unused).
+	 * @param array<string, string|bool> $assoc_args Flags.
+	 */
+	public function status( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$row = array(
+			'state'             => BotProtection::get_configured_state(),
+			'wp_cloud'          => BotProtection::is_wp_cloud() ? 'yes' : 'no',
+			'mu_plugin_present' => BotProtection::is_mu_plugin_present() ? 'yes' : 'no',
+		);
+
+		$fields = isset( $assoc_args['fields'] )
+			? \array_map( 'trim', \explode( ',', (string) $assoc_args['fields'] ) )
+			: self::DEFAULT_FIELDS;
+
+		$formatter = new \WP_CLI\Formatter( $assoc_args, $fields );
+		$formatter->display_items( array( $row ) );
+	}
+
+	/**
+	 * Sets the bot protection enforcement state.
+	 *
+	 * `inherit` leaves WP Cloud's own enablement tiers untouched; `on` and `off`
+	 * force the state via the `wpcloud_bot_protection_enable` filter, overriding
+	 * every other tier (including any client-level percentage rollout).
+	 *
+	 * ## OPTIONS
+	 *
+	 * <state>
+	 * : The enforcement state.
+	 * ---
+	 * options:
+	 *   - inherit
+	 *   - on
+	 *   - off
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp atlantis bot-protection set on
+	 *     $ wp atlantis bot-protection set off
+	 *     $ wp atlantis bot-protection set inherit
+	 *
+	 * @param array<int, string>         $args       Positional args: <state>.
+	 * @param array<string, string|bool> $assoc_args Flags (unused).
+	 */
+	public function set( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$state = (string) ( $args[0] ?? '' );
+
+		if ( BotProtection::get_configured_state() === $state ) {
+			\WP_CLI::log( \sprintf( "Bot protection enforcement is already '%s'; no change.", $state ) );
+			$this->maybe_warn_no_effect( $state );
+			return;
+		}
+
+		$result = BotProtection::set_state( $state );
+		if ( \is_wp_error( $result ) ) {
+			\WP_CLI::error( $result->get_error_message() );
+		}
+
+		\WP_CLI::success( \sprintf( "Bot protection enforcement set to '%s'.", $state ) );
+		$this->maybe_warn_no_effect( $state );
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Warns that a force on/off has no effect when the site is not WP Cloud.
+	 *
+	 * @param string $state The enforcement state that was requested.
+	 *
+	 * @return void
+	 */
+	private function maybe_warn_no_effect( string $state ): void {
+		$forces = \in_array( $state, array( BotProtection::STATE_ON, BotProtection::STATE_OFF ), true );
+		if ( $forces && ! BotProtection::is_wp_cloud() ) {
+			\WP_CLI::warning( 'This site is not a WP Cloud site, so this setting has no effect here.' );
+		}
+	}
+
+	// endregion
+}

--- a/src/Modules.php
+++ b/src/Modules.php
@@ -6,6 +6,7 @@ use A8C\SpecialProjects\Atlantis\Modules\Colophon\Colophon;
 use A8C\SpecialProjects\Atlantis\Modules\Tracking\Tracking;
 use A8C\SpecialProjects\Atlantis\Modules\Autoupdates\AutoUpdatePluginsFilter;
 use A8C\SpecialProjects\Atlantis\Modules\AbstractModule;
+use A8C\SpecialProjects\Atlantis\Modules\BotProtection\BotProtection;
 use A8C\SpecialProjects\Atlantis\Modules\Messages\Messages;
 
 
@@ -60,6 +61,7 @@ class Modules {
 		$this->try_initialize_module( 'colophon', static fn() => new Colophon() );
 		$this->try_initialize_module( 'tracking', static fn() => new Tracking() );
 		$this->try_initialize_module( 'autoupdates', static fn() => new AutoUpdatePluginsFilter() );
+		$this->try_initialize_module( 'bot-protection', static fn() => new BotProtection() );
 	}
 
 	/**

--- a/src/Modules/BotProtection/BotProtection.php
+++ b/src/Modules/BotProtection/BotProtection.php
@@ -125,7 +125,7 @@ class BotProtection extends AbstractModule {
 	 * @version 1.4.0
 	 */
 	public function get_description(): string {
-		return __( 'Controls WP Cloud Bot Protection (login and password-reset gating) on WP Cloud sites. Use the enforcement control to force it on or off; "Inherit" leaves the WP Cloud default untouched.', 'a8csp-atlantis' );
+		return __( 'Controls WP Cloud Bot Protection (login and password-reset gating) on WP Cloud sites. Use the enforcement control to force it off; "Inherit" leaves the WP Cloud default untouched.', 'a8csp-atlantis' );
 	}
 
 	/**
@@ -164,7 +164,7 @@ class BotProtection extends AbstractModule {
 	 *
 	 * Renders a single "Enforcement" dropdown as the module's only control.
 	 * The base Enabled checkbox is intentionally omitted — the module is
-	 * mandatory, so the dropdown (inherit/on/off) is the one meaningful setting.
+	 * mandatory, so the dropdown (inherit/off) is the one meaningful setting.
 	 *
 	 * @since   1.4.0
 	 * @version 1.4.0

--- a/src/Modules/BotProtection/BotProtection.php
+++ b/src/Modules/BotProtection/BotProtection.php
@@ -11,21 +11,25 @@ defined( 'ABSPATH' ) || exit;
  *
  * WP Cloud sites ship a `wpcloud-bot-protection` mu-plugin (the external name
  * for "blackbox") that gates the login and password-reset forms. Its loader
- * runs late on `plugins_loaded` and resolves enablement through the
- * `wpcloud_bot_protection_enable` filter, which overrides every other tier
- * (the `WPC_BOT_PROTECTION_ENABLED` constant, the platform define, and the
- * client-level percentage rollout).
+ * runs late on `plugins_loaded`; enablement comes from the loader's tiers
+ * (the `WPC_BOT_PROTECTION_ENABLED` constant, a platform define, and a
+ * client-level percentage rollout), and the `wpcloud_bot_protection_enable`
+ * filter acts as a per-request override. In the currently deployed loader that
+ * override reliably *disables* but does not *enable* — so this module is a
+ * per-site off-switch/override, not an enabler (enablement is done via the
+ * tiers, e.g. the constant or a client-level rollout).
  *
- * This module is Team 51's single control plane for that filter across the
- * fleet. It is mandatory (always loaded) and exposes one setting — the
- * enforcement `state`:
+ * It is mandatory (always loaded) and exposes one setting — the enforcement
+ * `state`:
  *
  * - `inherit` (default): register nothing, leaving WP Cloud's own tiers to
  *   decide. Ships as a no-op so rolling this module out changes no behavior.
- * - `on`: force-enable via `__return_true`.
  * - `off`: force-disable via `__return_false` — a hard override for a site
  *   where protection is causing problems, even if a client-level rollout
  *   would otherwise enable it.
+ *
+ * Additionally, on non-production environments protection is forced off (see
+ * initialize()), since staging/dev sites commonly run login automation.
  *
  * The filter is registered at `PHP_INT_MAX` priority so our verdict is the
  * final say. Registration happens during `plugins_loaded` (priority 10, via
@@ -59,16 +63,6 @@ class BotProtection extends AbstractModule {
 	public const STATE_INHERIT = 'inherit';
 
 	/**
-	 * Enforcement state: force bot protection on.
-	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
-	 *
-	 * @var string
-	 */
-	public const STATE_ON = 'on';
-
-	/**
 	 * Enforcement state: force bot protection off.
 	 *
 	 * @since   1.4.0
@@ -86,7 +80,7 @@ class BotProtection extends AbstractModule {
 	 *
 	 * @var array<int, string>
 	 */
-	public const VALID_STATES = array( self::STATE_INHERIT, self::STATE_ON, self::STATE_OFF );
+	public const VALID_STATES = array( self::STATE_INHERIT, self::STATE_OFF );
 
 	/**
 	 * The WP Cloud filter that gates bot protection enablement.
@@ -153,31 +147,21 @@ class BotProtection extends AbstractModule {
 	 * @version 1.4.0
 	 */
 	protected function initialize(): void {
-		$state = self::get_configured_state();
-
 		// Non-production safety: staging/dev sites frequently run login
 		// automation (CI/e2e suites, uptime and synthetic-login monitors,
 		// scripted provisioning) that bot protection would challenge or block,
-		// so force it off there by default. An explicit `on` still wins, so a
-		// site can be opted in deliberately (e.g. to test bot protection).
-		if ( self::STATE_ON !== $state && ! self::is_production() ) {
+		// so force it off there. Opt a specific non-production site back in with
+		// the `a8csp_atlantis_bot_protection_is_production` filter.
+		if ( ! self::is_production() ) {
 			add_filter( self::FILTER, '__return_false', PHP_INT_MAX );
 			return;
 		}
 
-		switch ( $state ) {
-			case self::STATE_ON:
-				add_filter( self::FILTER, '__return_true', PHP_INT_MAX );
-				break;
-
-			case self::STATE_OFF:
-				add_filter( self::FILTER, '__return_false', PHP_INT_MAX );
-				break;
-
-			case self::STATE_INHERIT:
-			default:
-				// Register nothing — WP Cloud's own enablement tiers decide.
-				break;
+		// `off` forces protection off (a hard override, even against a
+		// client-level rollout). `inherit` registers nothing and lets WP Cloud's
+		// own enablement tiers decide.
+		if ( self::STATE_OFF === self::get_configured_state() ) {
+			add_filter( self::FILTER, '__return_false', PHP_INT_MAX );
 		}
 	}
 
@@ -218,7 +202,6 @@ class BotProtection extends AbstractModule {
 
 				$choices = array(
 					self::STATE_INHERIT => __( 'Inherit — leave the WP Cloud default untouched', 'a8csp-atlantis' ),
-					self::STATE_ON      => __( 'On — force bot protection enabled', 'a8csp-atlantis' ),
 					self::STATE_OFF     => __( 'Off — force bot protection disabled', 'a8csp-atlantis' ),
 				);
 
@@ -233,8 +216,8 @@ class BotProtection extends AbstractModule {
 				}
 				echo '</select>';
 
-				// The dropdown is a no-op unless a listener is actually hooked to
-				// the filter: that requires both WP Cloud credentials and the
+				// `Off` is a no-op unless a listener is actually hooked to the
+				// filter: that requires both WP Cloud credentials and the
 				// mu-plugin. Name whichever precondition is missing so an operator
 				// reacting to a lockout is not misled into thinking Off took effect.
 				$notice = '';
@@ -242,8 +225,8 @@ class BotProtection extends AbstractModule {
 					$notice = __( 'This site is not a WP Cloud site, so this setting has no effect here.', 'a8csp-atlantis' );
 				} elseif ( ! self::is_mu_plugin_present() ) {
 					$notice = __( 'The WP Cloud bot protection mu-plugin is not present on this site, so this setting has no effect here.', 'a8csp-atlantis' );
-				} elseif ( self::STATE_ON !== $state && ! self::is_production() ) {
-					$notice = __( 'This is a non-production environment, so bot protection is forced off here unless Enforcement is set to On.', 'a8csp-atlantis' );
+				} elseif ( ! self::is_production() ) {
+					$notice = __( 'This is a non-production environment, so bot protection is forced off here regardless of this setting.', 'a8csp-atlantis' );
 				}
 
 				if ( '' !== $notice ) {

--- a/src/Modules/BotProtection/BotProtection.php
+++ b/src/Modules/BotProtection/BotProtection.php
@@ -1,0 +1,270 @@
+<?php declare( strict_types=1 );
+
+namespace A8C\SpecialProjects\Atlantis\Modules\BotProtection;
+
+use A8C\SpecialProjects\Atlantis\Modules\AbstractModule;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WP Cloud Bot Protection module.
+ *
+ * WP Cloud sites ship a `wpcloud-bot-protection` mu-plugin (the external name
+ * for "blackbox") that gates the login and password-reset forms. Its loader
+ * runs late on `plugins_loaded` and resolves enablement through the
+ * `wpcloud_bot_protection_enable` filter, which overrides every other tier
+ * (the `WPC_BOT_PROTECTION_ENABLED` constant, the platform define, and the
+ * client-level percentage rollout).
+ *
+ * This module is Team 51's single control plane for that filter across the
+ * fleet. It is mandatory (always loaded) and exposes one setting — the
+ * enforcement `state`:
+ *
+ * - `inherit` (default): register nothing, leaving WP Cloud's own tiers to
+ *   decide. Ships as a no-op so rolling this module out changes no behavior.
+ * - `on`: force-enable via `__return_true`.
+ * - `off`: force-disable via `__return_false` — a hard override for a site
+ *   where protection is causing problems, even if a client-level rollout
+ *   would otherwise enable it.
+ *
+ * The filter is registered at `PHP_INT_MAX` priority so our verdict is the
+ * final say. Registration happens during `plugins_loaded` (priority 10, via
+ * the plugin bootstrap), which is before the mu-plugin loader evaluates the
+ * filter at `PHP_INT_MAX` priority, so the timing is guaranteed.
+ *
+ * @since   1.4.0
+ * @version 1.4.0
+ */
+class BotProtection extends AbstractModule {
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * The module's human-readable name. Drives the settings option key.
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 *
+	 * @var string
+	 */
+	private const NAME = 'Bot Protection';
+
+	/**
+	 * Enforcement state: defer to WP Cloud's own enablement tiers.
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 *
+	 * @var string
+	 */
+	public const STATE_INHERIT = 'inherit';
+
+	/**
+	 * Enforcement state: force bot protection on.
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 *
+	 * @var string
+	 */
+	public const STATE_ON = 'on';
+
+	/**
+	 * Enforcement state: force bot protection off.
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 *
+	 * @var string
+	 */
+	public const STATE_OFF = 'off';
+
+	/**
+	 * The WP Cloud filter that gates bot protection enablement.
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 *
+	 * @var string
+	 */
+	private const FILTER = 'wpcloud_bot_protection_enable';
+
+	/**
+	 * The WP Cloud mu-plugin loader function, used to detect the mu-plugin.
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 *
+	 * @var string
+	 */
+	private const LOADER_FUNCTION = 'wpcloud_bot_protection_loader';
+
+	// endregion
+
+	// region INHERITED METHODS
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 */
+	public function get_name(): string {
+		return self::NAME;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 */
+	public function get_description(): string {
+		return __( 'Controls WP Cloud Bot Protection (login and password-reset gating) on WP Cloud sites. Use the enforcement control to force it on or off; "Inherit" leaves the WP Cloud default untouched.', 'a8csp-atlantis' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * This module is always loaded so its enforcement state is authoritative;
+	 * the single control is the `state` setting (defaulting to `inherit`, a
+	 * no-op), not an enable/disable toggle.
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 */
+	public function is_mandatory(): bool {
+		return true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 */
+	protected function initialize(): void {
+		switch ( self::get_configured_state() ) {
+			case self::STATE_ON:
+				add_filter( self::FILTER, '__return_true', PHP_INT_MAX );
+				break;
+
+			case self::STATE_OFF:
+				add_filter( self::FILTER, '__return_false', PHP_INT_MAX );
+				break;
+
+			case self::STATE_INHERIT:
+			default:
+				// Register nothing — WP Cloud's own enablement tiers decide.
+				break;
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Renders a single "Enforcement" dropdown as the module's only control.
+	 * The base Enabled checkbox is intentionally omitted — the module is
+	 * mandatory, so the dropdown (inherit/on/off) is the one meaningful setting.
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 */
+	public function register_settings(): void {
+		$option_name = a8csp_atlantis_generate_module_settings_key( $this->get_name() );
+		register_setting( 'a8csp_modules_group', $option_name );
+
+		add_settings_section(
+			"{$option_name}_section",
+			$this->get_name(),
+			function (): void {
+				echo wp_kses_post( wpautop( $this->get_description() ) );
+			},
+			'a8csp-atlantis-modules'
+		);
+
+		add_settings_field(
+			"{$option_name}_state",
+			__( 'Enforcement', 'a8csp-atlantis' ),
+			function ( array $args ): void {
+				$settings = a8csp_atlantis_get_module_settings( $this->get_name() );
+				$state    = isset( $settings['state'] ) ? (string) $settings['state'] : self::STATE_INHERIT;
+
+				$choices = array(
+					self::STATE_INHERIT => __( 'Inherit — leave the WP Cloud default untouched', 'a8csp-atlantis' ),
+					self::STATE_ON      => __( 'On — force bot protection enabled', 'a8csp-atlantis' ),
+					self::STATE_OFF     => __( 'Off — force bot protection disabled', 'a8csp-atlantis' ),
+				);
+
+				echo '<select name="' . esc_attr( $args['option_name'] ) . '[state]">';
+				foreach ( $choices as $value => $label ) {
+					printf(
+						'<option value="%s" %s>%s</option>',
+						esc_attr( $value ),
+						selected( $state, $value, false ),
+						esc_html( $label )
+					);
+				}
+				echo '</select>';
+
+				if ( ! self::is_wp_cloud() ) {
+					echo '<p class="description">' . esc_html__( 'This site is not a WP Cloud site, so this setting has no effect here.', 'a8csp-atlantis' ) . '</p>';
+				}
+			},
+			'a8csp-atlantis-modules',
+			"{$option_name}_section",
+			array( 'option_name' => $option_name )
+		);
+	}
+
+	// endregion
+
+	// region METHODS
+
+	/**
+	 * Returns the configured enforcement state, sanitized to a known value.
+	 *
+	 * Exposed statically so the REST status controller (and, later, the
+	 * companion Team 51 CLI command) can report the site's state without a
+	 * module instance.
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 *
+	 * @return  string One of the STATE_* constants.
+	 */
+	public static function get_configured_state(): string {
+		$settings = a8csp_atlantis_get_module_settings( self::NAME );
+		$state    = isset( $settings['state'] ) ? (string) $settings['state'] : self::STATE_INHERIT;
+
+		return in_array( $state, array( self::STATE_INHERIT, self::STATE_ON, self::STATE_OFF ), true )
+			? $state
+			: self::STATE_INHERIT;
+	}
+
+	/**
+	 * Whether this is a WP Cloud site (the credentials the mu-plugin requires).
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 *
+	 * @return  bool
+	 */
+	public static function is_wp_cloud(): bool {
+		return defined( 'ATOMIC_SITE_ID' ) && '' !== (string) constant( 'ATOMIC_SITE_ID' )
+			&& defined( 'ATOMIC_SITE_API_KEY' ) && '' !== (string) constant( 'ATOMIC_SITE_API_KEY' );
+	}
+
+	/**
+	 * Whether the WP Cloud bot protection mu-plugin is present on this site.
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 *
+	 * @return  bool
+	 */
+	public static function is_mu_plugin_present(): bool {
+		return function_exists( self::LOADER_FUNCTION );
+	}
+
+	// endregion
+}

--- a/src/Modules/BotProtection/BotProtection.php
+++ b/src/Modules/BotProtection/BotProtection.php
@@ -79,6 +79,16 @@ class BotProtection extends AbstractModule {
 	public const STATE_OFF = 'off';
 
 	/**
+	 * All valid enforcement states.
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 *
+	 * @var array<int, string>
+	 */
+	public const VALID_STATES = array( self::STATE_INHERIT, self::STATE_ON, self::STATE_OFF );
+
+	/**
 	 * The WP Cloud filter that gates bot protection enablement.
 	 *
 	 * @since   1.4.0
@@ -236,9 +246,45 @@ class BotProtection extends AbstractModule {
 		$settings = a8csp_atlantis_get_module_settings( self::NAME );
 		$state    = isset( $settings['state'] ) ? (string) $settings['state'] : self::STATE_INHERIT;
 
-		return in_array( $state, array( self::STATE_INHERIT, self::STATE_ON, self::STATE_OFF ), true )
-			? $state
-			: self::STATE_INHERIT;
+		return in_array( $state, self::VALID_STATES, true ) ? $state : self::STATE_INHERIT;
+	}
+
+	/**
+	 * Persists the enforcement state, preserving any other stored sub-settings.
+	 *
+	 * Exposed statically as the single write path for the setting, shared by the
+	 * settings form and the `wp atlantis bot-protection set` command.
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 *
+	 * @param   string $state One of the STATE_* constants.
+	 *
+	 * @return  true|\WP_Error True on success, WP_Error if the state is invalid.
+	 */
+	public static function set_state( string $state ): true|\WP_Error {
+		if ( ! in_array( $state, self::VALID_STATES, true ) ) {
+			return new \WP_Error(
+				'a8csp_atlantis_invalid_bot_protection_state',
+				wp_sprintf(
+					/* translators: 1: provided value, 2: comma-separated list of valid values */
+					__( 'Invalid enforcement state "%1$s". Valid values: %2$s.', 'a8csp-atlantis' ),
+					$state,
+					implode( ', ', self::VALID_STATES )
+				)
+			);
+		}
+
+		$settings_key      = a8csp_atlantis_generate_module_settings_key( self::NAME );
+		$settings          = a8csp_atlantis_get_module_settings( self::NAME );
+		$settings['state'] = $state;
+		if ( ! isset( $settings['enabled'] ) ) {
+			$settings['enabled'] = '1';
+		}
+
+		update_option( $settings_key, $settings );
+
+		return true;
 	}
 
 	/**

--- a/src/Modules/BotProtection/BotProtection.php
+++ b/src/Modules/BotProtection/BotProtection.php
@@ -153,7 +153,19 @@ class BotProtection extends AbstractModule {
 	 * @version 1.4.0
 	 */
 	protected function initialize(): void {
-		switch ( self::get_configured_state() ) {
+		$state = self::get_configured_state();
+
+		// Non-production safety: staging/dev sites frequently run login
+		// automation (CI/e2e suites, uptime and synthetic-login monitors,
+		// scripted provisioning) that bot protection would challenge or block,
+		// so force it off there by default. An explicit `on` still wins, so a
+		// site can be opted in deliberately (e.g. to test bot protection).
+		if ( self::STATE_ON !== $state && ! self::is_production() ) {
+			add_filter( self::FILTER, '__return_false', PHP_INT_MAX );
+			return;
+		}
+
+		switch ( $state ) {
 			case self::STATE_ON:
 				add_filter( self::FILTER, '__return_true', PHP_INT_MAX );
 				break;
@@ -230,6 +242,8 @@ class BotProtection extends AbstractModule {
 					$notice = __( 'This site is not a WP Cloud site, so this setting has no effect here.', 'a8csp-atlantis' );
 				} elseif ( ! self::is_mu_plugin_present() ) {
 					$notice = __( 'The WP Cloud bot protection mu-plugin is not present on this site, so this setting has no effect here.', 'a8csp-atlantis' );
+				} elseif ( self::STATE_ON !== $state && ! self::is_production() ) {
+					$notice = __( 'This is a non-production environment, so bot protection is forced off here unless Enforcement is set to On.', 'a8csp-atlantis' );
 				}
 
 				if ( '' !== $notice ) {
@@ -374,6 +388,35 @@ class BotProtection extends AbstractModule {
 	 */
 	public static function is_mu_plugin_present(): bool {
 		return function_exists( self::LOADER_FUNCTION );
+	}
+
+	/**
+	 * Whether the current environment should be treated as production.
+	 *
+	 * On non-production environments bot protection is forced off unless the
+	 * state is explicitly `on` (see initialize()), since staging/dev sites
+	 * commonly run login automation that protection would break.
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 *
+	 * @return  bool
+	 */
+	public static function is_production(): bool {
+		$is_production = ! function_exists( 'wp_get_environment_type' ) || 'production' === wp_get_environment_type();
+
+		/**
+		 * Filters whether Bot Protection treats the current site as production.
+		 *
+		 * Return false to have protection forced off here (unless the state is
+		 * `on`); return true to opt a non-production site back into the normal
+		 * enablement tiers.
+		 *
+		 * @since 1.4.0
+		 *
+		 * @param bool $is_production Whether the environment type is `production`.
+		 */
+		return (bool) apply_filters( 'a8csp_atlantis_bot_protection_is_production', $is_production );
 	}
 
 	// endregion

--- a/src/Modules/BotProtection/BotProtection.php
+++ b/src/Modules/BotProtection/BotProtection.php
@@ -28,8 +28,10 @@ defined( 'ABSPATH' ) || exit;
  *   where protection is causing problems, even if a client-level rollout
  *   would otherwise enable it.
  *
- * Additionally, on non-production environments protection is forced off (see
- * initialize()), since staging/dev sites commonly run login automation.
+ * The `state` applies uniformly across environments: staging/dev sites inherit
+ * by default just like production, so their protection tracks whatever WP
+ * Cloud's tiers decide. A site that must stay clear for login automation is
+ * set to `off` explicitly.
  *
  * The filter is registered at `PHP_INT_MAX` priority so our verdict is the
  * final say. Registration happens during `plugins_loaded` (priority 10, via
@@ -147,19 +149,11 @@ class BotProtection extends AbstractModule {
 	 * @version 1.4.0
 	 */
 	protected function initialize(): void {
-		// Non-production safety: staging/dev sites frequently run login
-		// automation (CI/e2e suites, uptime and synthetic-login monitors,
-		// scripted provisioning) that bot protection would challenge or block,
-		// so force it off there. Opt a specific non-production site back in with
-		// the `a8csp_atlantis_bot_protection_is_production` filter.
-		if ( ! self::is_production() ) {
-			add_filter( self::FILTER, '__return_false', PHP_INT_MAX );
-			return;
-		}
-
 		// `off` forces protection off (a hard override, even against a
 		// client-level rollout). `inherit` registers nothing and lets WP Cloud's
-		// own enablement tiers decide.
+		// own enablement tiers decide. This applies uniformly across
+		// environments — a staging site that runs login automation is set to
+		// `off` explicitly rather than gated on the environment type.
 		if ( self::STATE_OFF === self::get_configured_state() ) {
 			add_filter( self::FILTER, '__return_false', PHP_INT_MAX );
 		}
@@ -225,8 +219,6 @@ class BotProtection extends AbstractModule {
 					$notice = __( 'This site is not a WP Cloud site, so this setting has no effect here.', 'a8csp-atlantis' );
 				} elseif ( ! self::is_mu_plugin_present() ) {
 					$notice = __( 'The WP Cloud bot protection mu-plugin is not present on this site, so this setting has no effect here.', 'a8csp-atlantis' );
-				} elseif ( ! self::is_production() ) {
-					$notice = __( 'This is a non-production environment, so bot protection is forced off here regardless of this setting.', 'a8csp-atlantis' );
 				}
 
 				if ( '' !== $notice ) {
@@ -371,35 +363,6 @@ class BotProtection extends AbstractModule {
 	 */
 	public static function is_mu_plugin_present(): bool {
 		return function_exists( self::LOADER_FUNCTION );
-	}
-
-	/**
-	 * Whether the current environment should be treated as production.
-	 *
-	 * On non-production environments bot protection is forced off unless the
-	 * state is explicitly `on` (see initialize()), since staging/dev sites
-	 * commonly run login automation that protection would break.
-	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
-	 *
-	 * @return  bool
-	 */
-	public static function is_production(): bool {
-		$is_production = ! function_exists( 'wp_get_environment_type' ) || 'production' === wp_get_environment_type();
-
-		/**
-		 * Filters whether Bot Protection treats the current site as production.
-		 *
-		 * Return false to have protection forced off here (unless the state is
-		 * `on`); return true to opt a non-production site back into the normal
-		 * enablement tiers.
-		 *
-		 * @since 1.4.0
-		 *
-		 * @param bool $is_production Whether the environment type is `production`.
-		 */
-		return (bool) apply_filters( 'a8csp_atlantis_bot_protection_is_production', $is_production );
 	}
 
 	// endregion

--- a/src/Modules/BotProtection/BotProtection.php
+++ b/src/Modules/BotProtection/BotProtection.php
@@ -292,7 +292,7 @@ class BotProtection extends AbstractModule {
 	/**
 	 * Persists the enforcement state, preserving any other stored sub-settings.
 	 *
-	 * The programmatic write path, used by the `wp atlantis bot-protection set`
+	 * The programmatic write path, used by the `wp atlantis module bot-protection set`
 	 * command. (The settings form writes through the option's sanitize_callback,
 	 * self::sanitize_settings(), instead.) Validates $state, keeps the stored
 	 * `enabled` flag, and reports a genuine persistence failure.

--- a/src/Modules/BotProtection/BotProtection.php
+++ b/src/Modules/BotProtection/BotProtection.php
@@ -181,7 +181,11 @@ class BotProtection extends AbstractModule {
 	 */
 	public function register_settings(): void {
 		$option_name = a8csp_atlantis_generate_module_settings_key( $this->get_name() );
-		register_setting( 'a8csp_modules_group', $option_name );
+		register_setting(
+			'a8csp_modules_group',
+			$option_name,
+			array( 'sanitize_callback' => array( self::class, 'sanitize_settings' ) )
+		);
 
 		add_settings_section(
 			"{$option_name}_section",
@@ -197,7 +201,8 @@ class BotProtection extends AbstractModule {
 			__( 'Enforcement', 'a8csp-atlantis' ),
 			function ( array $args ): void {
 				$settings = a8csp_atlantis_get_module_settings( $this->get_name() );
-				$state    = isset( $settings['state'] ) ? (string) $settings['state'] : self::STATE_INHERIT;
+				$state    = isset( $settings['state'] ) && is_string( $settings['state'] ) ? $settings['state'] : self::STATE_INHERIT;
+				$field_id = (string) ( $args['label_for'] ?? $args['option_name'] . '_state' );
 
 				$choices = array(
 					self::STATE_INHERIT => __( 'Inherit — leave the WP Cloud default untouched', 'a8csp-atlantis' ),
@@ -205,7 +210,7 @@ class BotProtection extends AbstractModule {
 					self::STATE_OFF     => __( 'Off — force bot protection disabled', 'a8csp-atlantis' ),
 				);
 
-				echo '<select name="' . esc_attr( $args['option_name'] ) . '[state]">';
+				echo '<select id="' . esc_attr( $field_id ) . '" name="' . esc_attr( $args['option_name'] ) . '[state]">';
 				foreach ( $choices as $value => $label ) {
 					printf(
 						'<option value="%s" %s>%s</option>',
@@ -216,13 +221,27 @@ class BotProtection extends AbstractModule {
 				}
 				echo '</select>';
 
+				// The dropdown is a no-op unless a listener is actually hooked to
+				// the filter: that requires both WP Cloud credentials and the
+				// mu-plugin. Name whichever precondition is missing so an operator
+				// reacting to a lockout is not misled into thinking Off took effect.
+				$notice = '';
 				if ( ! self::is_wp_cloud() ) {
-					echo '<p class="description">' . esc_html__( 'This site is not a WP Cloud site, so this setting has no effect here.', 'a8csp-atlantis' ) . '</p>';
+					$notice = __( 'This site is not a WP Cloud site, so this setting has no effect here.', 'a8csp-atlantis' );
+				} elseif ( ! self::is_mu_plugin_present() ) {
+					$notice = __( 'The WP Cloud bot protection mu-plugin is not present on this site, so this setting has no effect here.', 'a8csp-atlantis' );
+				}
+
+				if ( '' !== $notice ) {
+					echo '<p class="description">' . esc_html( $notice ) . '</p>';
 				}
 			},
 			'a8csp-atlantis-modules',
 			"{$option_name}_section",
-			array( 'option_name' => $option_name )
+			array(
+				'option_name' => $option_name,
+				'label_for'   => "{$option_name}_state",
+			)
 		);
 	}
 
@@ -244,9 +263,41 @@ class BotProtection extends AbstractModule {
 	 */
 	public static function get_configured_state(): string {
 		$settings = a8csp_atlantis_get_module_settings( self::NAME );
-		$state    = isset( $settings['state'] ) ? (string) $settings['state'] : self::STATE_INHERIT;
+		$state    = isset( $settings['state'] ) && is_string( $settings['state'] ) ? $settings['state'] : self::STATE_INHERIT;
 
 		return in_array( $state, self::VALID_STATES, true ) ? $state : self::STATE_INHERIT;
+	}
+
+	/**
+	 * Sanitizes the module settings on save.
+	 *
+	 * Registered as the option's `sanitize_callback`. Whitelists `state` against
+	 * the STATE_* constants (falling back to `inherit`) and carries the stored
+	 * `enabled` flag forward — this module's form intentionally omits the base
+	 * Enabled checkbox, which would otherwise drop that key on every save.
+	 *
+	 * @since   1.4.0
+	 * @version 1.4.0
+	 *
+	 * @param   mixed $input The raw option value submitted by the settings form.
+	 *
+	 * @return  array<string, string>
+	 */
+	public static function sanitize_settings( mixed $input ): array {
+		$input = is_array( $input ) ? $input : array();
+
+		$state = isset( $input['state'] ) && is_string( $input['state'] ) ? $input['state'] : self::STATE_INHERIT;
+		if ( ! in_array( $state, self::VALID_STATES, true ) ) {
+			$state = self::STATE_INHERIT;
+		}
+
+		$stored  = a8csp_atlantis_get_module_settings( self::NAME );
+		$enabled = isset( $stored['enabled'] ) && is_string( $stored['enabled'] ) ? $stored['enabled'] : '1';
+
+		return array(
+			'enabled' => $enabled,
+			'state'   => $state,
+		);
 	}
 
 	/**

--- a/src/Modules/BotProtection/BotProtection.php
+++ b/src/Modules/BotProtection/BotProtection.php
@@ -303,15 +303,18 @@ class BotProtection extends AbstractModule {
 	/**
 	 * Persists the enforcement state, preserving any other stored sub-settings.
 	 *
-	 * Exposed statically as the single write path for the setting, shared by the
-	 * settings form and the `wp atlantis bot-protection set` command.
+	 * The programmatic write path, used by the `wp atlantis bot-protection set`
+	 * command. (The settings form writes through the option's sanitize_callback,
+	 * self::sanitize_settings(), instead.) Validates $state, keeps the stored
+	 * `enabled` flag, and reports a genuine persistence failure.
 	 *
 	 * @since   1.4.0
 	 * @version 1.4.0
 	 *
 	 * @param   string $state One of the STATE_* constants.
 	 *
-	 * @return  true|\WP_Error True on success, WP_Error if the state is invalid.
+	 * @return  true|\WP_Error True on success, WP_Error if the state is invalid
+	 *                         or could not be persisted.
 	 */
 	public static function set_state( string $state ): true|\WP_Error {
 		if ( ! in_array( $state, self::VALID_STATES, true ) ) {
@@ -327,13 +330,23 @@ class BotProtection extends AbstractModule {
 		}
 
 		$settings_key      = a8csp_atlantis_generate_module_settings_key( self::NAME );
-		$settings          = a8csp_atlantis_get_module_settings( self::NAME );
+		$current           = a8csp_atlantis_get_module_settings( self::NAME );
+		$settings          = $current;
 		$settings['state'] = $state;
 		if ( ! isset( $settings['enabled'] ) ) {
 			$settings['enabled'] = '1';
 		}
 
-		update_option( $settings_key, $settings );
+		if ( $settings === $current ) {
+			return true; // Already persisted; nothing to write.
+		}
+
+		if ( ! update_option( $settings_key, $settings ) ) {
+			return new \WP_Error(
+				'a8csp_atlantis_bot_protection_save_failed',
+				__( 'Failed to persist the bot protection enforcement state.', 'a8csp-atlantis' )
+			);
+		}
 
 		return true;
 	}

--- a/src/Modules/BotProtection/BotProtection.php
+++ b/src/Modules/BotProtection/BotProtection.php
@@ -38,8 +38,8 @@ defined( 'ABSPATH' ) || exit;
  * the plugin bootstrap), which is before the mu-plugin loader evaluates the
  * filter at `PHP_INT_MAX` priority, so the timing is guaranteed.
  *
- * @since   1.4.0
- * @version 1.4.0
+ * @since   1.3.0
+ * @version 1.3.0
  */
 class BotProtection extends AbstractModule {
 	// region FIELDS AND CONSTANTS
@@ -47,8 +47,8 @@ class BotProtection extends AbstractModule {
 	/**
 	 * The module's human-readable name. Drives the settings option key.
 	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
+	 * @since   1.3.0
+	 * @version 1.3.0
 	 *
 	 * @var string
 	 */
@@ -57,8 +57,8 @@ class BotProtection extends AbstractModule {
 	/**
 	 * Enforcement state: defer to WP Cloud's own enablement tiers.
 	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
+	 * @since   1.3.0
+	 * @version 1.3.0
 	 *
 	 * @var string
 	 */
@@ -67,8 +67,8 @@ class BotProtection extends AbstractModule {
 	/**
 	 * Enforcement state: force bot protection off.
 	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
+	 * @since   1.3.0
+	 * @version 1.3.0
 	 *
 	 * @var string
 	 */
@@ -77,8 +77,8 @@ class BotProtection extends AbstractModule {
 	/**
 	 * All valid enforcement states.
 	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
+	 * @since   1.3.0
+	 * @version 1.3.0
 	 *
 	 * @var array<int, string>
 	 */
@@ -87,8 +87,8 @@ class BotProtection extends AbstractModule {
 	/**
 	 * The WP Cloud filter that gates bot protection enablement.
 	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
+	 * @since   1.3.0
+	 * @version 1.3.0
 	 *
 	 * @var string
 	 */
@@ -97,8 +97,8 @@ class BotProtection extends AbstractModule {
 	/**
 	 * The WP Cloud mu-plugin loader function, used to detect the mu-plugin.
 	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
+	 * @since   1.3.0
+	 * @version 1.3.0
 	 *
 	 * @var string
 	 */
@@ -111,8 +111,8 @@ class BotProtection extends AbstractModule {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
+	 * @since   1.3.0
+	 * @version 1.3.0
 	 */
 	public function get_name(): string {
 		return self::NAME;
@@ -121,8 +121,8 @@ class BotProtection extends AbstractModule {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
+	 * @since   1.3.0
+	 * @version 1.3.0
 	 */
 	public function get_description(): string {
 		return __( 'Controls WP Cloud Bot Protection (login and password-reset gating) on WP Cloud sites. Use the enforcement control to force it off; "Inherit" leaves the WP Cloud default untouched.', 'a8csp-atlantis' );
@@ -135,8 +135,8 @@ class BotProtection extends AbstractModule {
 	 * the single control is the `state` setting (defaulting to `inherit`, a
 	 * no-op), not an enable/disable toggle.
 	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
+	 * @since   1.3.0
+	 * @version 1.3.0
 	 */
 	public function is_mandatory(): bool {
 		return true;
@@ -145,8 +145,8 @@ class BotProtection extends AbstractModule {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
+	 * @since   1.3.0
+	 * @version 1.3.0
 	 */
 	protected function initialize(): void {
 		// `off` forces protection off (a hard override, even against a
@@ -166,8 +166,8 @@ class BotProtection extends AbstractModule {
 	 * The base Enabled checkbox is intentionally omitted — the module is
 	 * mandatory, so the dropdown (inherit/off) is the one meaningful setting.
 	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
+	 * @since   1.3.0
+	 * @version 1.3.0
 	 */
 	public function register_settings(): void {
 		$option_name = a8csp_atlantis_generate_module_settings_key( $this->get_name() );
@@ -245,8 +245,8 @@ class BotProtection extends AbstractModule {
 	 * companion Team 51 CLI command) can report the site's state without a
 	 * module instance.
 	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
+	 * @since   1.3.0
+	 * @version 1.3.0
 	 *
 	 * @return  string One of the STATE_* constants.
 	 */
@@ -265,8 +265,8 @@ class BotProtection extends AbstractModule {
 	 * `enabled` flag forward — this module's form intentionally omits the base
 	 * Enabled checkbox, which would otherwise drop that key on every save.
 	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
+	 * @since   1.3.0
+	 * @version 1.3.0
 	 *
 	 * @param   mixed $input The raw option value submitted by the settings form.
 	 *
@@ -297,8 +297,8 @@ class BotProtection extends AbstractModule {
 	 * self::sanitize_settings(), instead.) Validates $state, keeps the stored
 	 * `enabled` flag, and reports a genuine persistence failure.
 	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
+	 * @since   1.3.0
+	 * @version 1.3.0
 	 *
 	 * @param   string $state One of the STATE_* constants.
 	 *
@@ -343,8 +343,8 @@ class BotProtection extends AbstractModule {
 	/**
 	 * Whether this is a WP Cloud site (the credentials the mu-plugin requires).
 	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
+	 * @since   1.3.0
+	 * @version 1.3.0
 	 *
 	 * @return  bool
 	 */
@@ -356,8 +356,8 @@ class BotProtection extends AbstractModule {
 	/**
 	 * Whether the WP Cloud bot protection mu-plugin is present on this site.
 	 *
-	 * @since   1.4.0
-	 * @version 1.4.0
+	 * @since   1.3.0
+	 * @version 1.3.0
 	 *
 	 * @return  bool
 	 */

--- a/src/Modules/BotProtection/README.md
+++ b/src/Modules/BotProtection/README.md
@@ -35,11 +35,12 @@ init (priority 10), before the mu-plugin loader evaluates the filter at
 
 Verified matrix:
 
-| `WPC_BOT_PROTECTION_ENABLED` | Atlantis `state` | Result                  |
-| ---------------------------- | ---------------- | ----------------------- |
-| `true`                       | `inherit`        | on                      |
-| `true`                       | `off`            | **off** (override wins) |
-| absent / `false`             | `inherit`        | off (no arming tier)    |
+| `WPC_BOT_PROTECTION_ENABLED` | Atlantis `state` | Result                    |
+| ---------------------------- | ---------------- | ------------------------- |
+| `true`                       | `inherit`        | on                        |
+| `true`                       | `off`            | **off** (override wins)   |
+| absent / `false`             | `inherit`        | off (no arming tier)      |
+| absent / `false`             | `off`            | off (nothing to override) |
 
 ## Environments
 

--- a/src/Modules/BotProtection/README.md
+++ b/src/Modules/BotProtection/README.md
@@ -1,0 +1,51 @@
+# Bot Protection
+
+Team 51's control plane for **WP Cloud Bot Protection** (the external name for
+"blackbox") — the login and password-reset gating shipped as the
+`wpcloud-bot-protection` mu-plugin on WP Cloud sites.
+
+The mu-plugin resolves enablement through the `wpcloud_bot_protection_enable`
+filter, evaluated late on `plugins_loaded`. That filter overrides every other
+tier: the `WPC_BOT_PROTECTION_ENABLED` constant, the platform define, and the
+client-level percentage rollout. This module drives that filter.
+
+## Enforcement states
+
+The module is mandatory (always loaded) and exposes a single `state` setting
+under **Atlantis → Modules → Bot Protection**:
+
+- `inherit` (default) — register nothing; WP Cloud's own tiers decide. Shipping
+  the module changes no behavior.
+- `on` — force enabled (`__return_true`).
+- `off` — force disabled (`__return_false`); a hard override for a site where
+  protection is causing problems, even against a client-level rollout.
+
+The filter is registered at `PHP_INT_MAX` priority so Atlantis's verdict is the
+final say, and only on the `on` / `off` states. Registration happens during the
+plugin's `plugins_loaded` init (priority 10), before the mu-plugin loader
+evaluates the filter at `PHP_INT_MAX`.
+
+## WP Cloud precondition
+
+The mu-plugin only loads where the WP Cloud credentials `ATOMIC_SITE_ID` and
+`ATOMIC_SITE_API_KEY` are defined. On any other site — or on a WP Cloud site
+that has not yet received the mu-plugin — nothing listens on the filter, so the
+setting is a no-op. The settings screen surfaces a notice in that case.
+
+## WP-CLI
+
+```sh
+wp atlantis bot-protection status
+wp atlantis bot-protection set <inherit|on|off>
+```
+
+## Status endpoint
+
+`GET /wp-json/a8csp-atlantis/v1/status` reports, under `modules.bot-protection`:
+
+- `state` — `inherit` / `on` / `off`. The authoritative enforcement signal.
+- `wp_cloud` — whether the WP Cloud credentials are present.
+- `mu_plugin_present` — whether the mu-plugin is loaded.
+
+The shared `enabled` field is always `true` for this mandatory module and does
+not indicate enforcement; read `state` instead.

--- a/src/Modules/BotProtection/README.md
+++ b/src/Modules/BotProtection/README.md
@@ -7,9 +7,10 @@ Team 51's control plane for **WP Cloud Bot Protection** (the external name for
 The mu-plugin resolves enablement from a set of tiers — the per-site
 `WPC_BOT_PROTECTION_ENABLED` constant, a platform define, and a client-level
 percentage rollout — and exposes the `wpcloud_bot_protection_enable` filter
-(evaluated late on `plugins_loaded`) as a per-request override. This module
-drives that filter. See **Enable vs. disable** below for an important
-limitation of the currently deployed loader.
+(evaluated late on `plugins_loaded`) as a per-request override. In the
+currently deployed loader that override reliably **disables** but does **not
+enable** (verified in a live WP Cloud environment). So this module is a
+per-site **off-switch / override**, not an enabler.
 
 ## Enforcement states
 
@@ -18,82 +19,64 @@ under **Atlantis → Modules → Bot Protection**:
 
 - `inherit` (default) — register nothing; WP Cloud's own tiers decide. Shipping
   the module changes no behavior.
-- `on` — force enabled (`__return_true`). **Caveat:** in the deployed loader
-  this only forces on where a tier has already armed the loader; it does not
-  enable a site that has no enabling tier (see **Enable vs. disable**).
 - `off` — force disabled (`__return_false`); a hard override for a site where
   protection is causing problems, even against a client-level rollout.
 
-The filter is registered at `PHP_INT_MAX` priority so Atlantis's verdict is the
-final say, and only on the `on` / `off` states. Registration happens during the
-plugin's `plugins_loaded` init (priority 10), before the mu-plugin loader
-evaluates the filter at `PHP_INT_MAX`.
+There is deliberately no `on`: because the filter cannot enable a site that no
+tier has armed, an `on` would be indistinguishable from `inherit` in every real
+case and only invite confusion. To **enable** a site, arm a tier — set
+`WPC_BOT_PROTECTION_ENABLED = true` (e.g. a one-off or a bulk `wp-config`
+script), or have the client enabled via the platform percentage rollout.
 
-## Enable vs. disable (important)
+The `off` filter is registered at `PHP_INT_MAX` priority so Atlantis's verdict
+is the final say. Registration happens during the plugin's `plugins_loaded`
+init (priority 10), before the mu-plugin loader evaluates the filter at
+`PHP_INT_MAX`.
 
-WP Cloud's *enablement* comes from the loader's tiers (the constant, a platform
-define, and the client-level percentage rollout). The
-`wpcloud_bot_protection_enable` filter this module drives is an **override**
-layered on top — and in the currently deployed loader that override reliably
-**disables** but does **not enable**. Verified in a live WP Cloud environment:
+Verified matrix:
 
 | `WPC_BOT_PROTECTION_ENABLED` | Atlantis `state` | Result                  |
 | ---------------------------- | ---------------- | ----------------------- |
 | `true`                       | `inherit`        | on                      |
-| `true`                       | `on`             | on                      |
 | `true`                       | `off`            | **off** (override wins) |
-| absent / `false`             | `on`             | **off** (no arming tier)|
-
-So:
-
-- **To disable a site — use `off`.** This is the module's primary, reliable
-  job: the per-site "escape hatch", including exempting automation/test sites.
-- **To enable a site — set `WPC_BOT_PROTECTION_ENABLED = true`** (or have the
-  client enabled via the platform percentage rollout). `on` alone cannot arm a
-  site that no tier has enabled.
-
-In short: `off` is the dependable lever, `inherit` respects the platform
-decision, and `on` means "force-on where the loader is already armed."
+| absent / `false`             | `inherit`        | off (no arming tier)    |
 
 ## Non-production environments
 
 On any environment where `wp_get_environment_type()` is not `production`,
-protection is **forced off** unless the state is explicitly `on`. Staging and
-development sites routinely run login automation — CI/e2e suites, uptime and
+protection is **forced off** regardless of `state`. Staging and development
+sites routinely run login automation — CI/e2e suites, uptime and
 synthetic-login monitors, scripted provisioning — that bot protection would
 challenge or block, so this keeps those sites clear by default (mirroring the
 Tracking module's production gating).
 
-- non-production + `inherit` or `off` → forced off
-- non-production + `on` → on (deliberate opt-in, e.g. to test protection)
-- production → states behave as described above
-
-The determination is filterable via `a8csp_atlantis_bot_protection_is_production`
-(return `true`/`false`) for sites where the environment type isn't set reliably.
+To opt a specific non-production site back in (e.g. to test protection),
+override the determination via the `a8csp_atlantis_bot_protection_is_production`
+filter (`return true`) — and arm an enabling tier as above.
 
 ## WP Cloud precondition
 
 The mu-plugin only loads where the WP Cloud credentials `ATOMIC_SITE_ID` and
 `ATOMIC_SITE_API_KEY` are defined. On any other site — or on a WP Cloud site
-that has not yet received the mu-plugin — nothing listens on the filter, so the
-setting is a no-op. The settings screen surfaces a notice in that case.
+that has not yet received the mu-plugin — nothing listens on the filter, so
+`off` is a no-op. The settings screen surfaces a notice in that case.
 
 ## WP-CLI
 
 ```sh
 wp atlantis bot-protection status
-wp atlantis bot-protection set <inherit|on|off>
+wp atlantis bot-protection set <inherit|off>
 ```
 
 ## Status endpoint
 
 `GET /wp-json/a8csp-atlantis/v1/status` reports, under `modules.bot-protection`:
 
-- `state` — `inherit` / `on` / `off`. The authoritative enforcement signal.
+- `state` — `inherit` / `off`. The authoritative enforcement signal.
 - `wp_cloud` — whether the WP Cloud credentials are present.
 - `mu_plugin_present` — whether the mu-plugin is loaded.
 - `environment` — the site's environment type; non-production forces protection
-  off unless `state` is `on`.
+  off regardless of `state`.
 
 The shared `enabled` field is always `true` for this mandatory module and does
 not indicate enforcement; read `state` instead.

--- a/src/Modules/BotProtection/README.md
+++ b/src/Modules/BotProtection/README.md
@@ -41,18 +41,14 @@ Verified matrix:
 | `true`                       | `off`            | **off** (override wins) |
 | absent / `false`             | `inherit`        | off (no arming tier)    |
 
-## Non-production environments
+## Environments
 
-On any environment where `wp_get_environment_type()` is not `production`,
-protection is **forced off** regardless of `state`. Staging and development
-sites routinely run login automation — CI/e2e suites, uptime and
-synthetic-login monitors, scripted provisioning — that bot protection would
-challenge or block, so this keeps those sites clear by default (mirroring the
-Tracking module's production gating).
-
-To opt a specific non-production site back in (e.g. to test protection),
-override the determination via the `a8csp_atlantis_bot_protection_is_production`
-filter (`return true`) — and arm an enabling tier as above.
+The `state` applies uniformly across environments — staging and development
+sites `inherit` by default just like production, so their protection tracks
+whatever WP Cloud's tiers decide. A non-production site that runs login
+automation (CI/e2e suites, uptime and synthetic-login monitors, scripted
+provisioning) and must stay clear is set to `off` explicitly, not gated on the
+environment type.
 
 ## WP Cloud precondition
 
@@ -75,8 +71,8 @@ wp atlantis bot-protection set <inherit|off>
 - `state` — `inherit` / `off`. The authoritative enforcement signal.
 - `wp_cloud` — whether the WP Cloud credentials are present.
 - `mu_plugin_present` — whether the mu-plugin is loaded.
-- `environment` — the site's environment type; non-production forces protection
-  off regardless of `state`.
+- `environment` — the site's environment type (informational; enforcement is
+  driven by `state`, not the environment).
 
 The shared `enabled` field is always `true` for this mandatory module and does
 not indicate enforcement; read `state` instead.

--- a/src/Modules/BotProtection/README.md
+++ b/src/Modules/BotProtection/README.md
@@ -4,10 +4,12 @@ Team 51's control plane for **WP Cloud Bot Protection** (the external name for
 "blackbox") — the login and password-reset gating shipped as the
 `wpcloud-bot-protection` mu-plugin on WP Cloud sites.
 
-The mu-plugin resolves enablement through the `wpcloud_bot_protection_enable`
-filter, evaluated late on `plugins_loaded`. That filter overrides every other
-tier: the `WPC_BOT_PROTECTION_ENABLED` constant, the platform define, and the
-client-level percentage rollout. This module drives that filter.
+The mu-plugin resolves enablement from a set of tiers — the per-site
+`WPC_BOT_PROTECTION_ENABLED` constant, a platform define, and a client-level
+percentage rollout — and exposes the `wpcloud_bot_protection_enable` filter
+(evaluated late on `plugins_loaded`) as a per-request override. This module
+drives that filter. See **Enable vs. disable** below for an important
+limitation of the currently deployed loader.
 
 ## Enforcement states
 
@@ -16,7 +18,9 @@ under **Atlantis → Modules → Bot Protection**:
 
 - `inherit` (default) — register nothing; WP Cloud's own tiers decide. Shipping
   the module changes no behavior.
-- `on` — force enabled (`__return_true`).
+- `on` — force enabled (`__return_true`). **Caveat:** in the deployed loader
+  this only forces on where a tier has already armed the loader; it does not
+  enable a site that has no enabling tier (see **Enable vs. disable**).
 - `off` — force disabled (`__return_false`); a hard override for a site where
   protection is causing problems, even against a client-level rollout.
 
@@ -24,6 +28,32 @@ The filter is registered at `PHP_INT_MAX` priority so Atlantis's verdict is the
 final say, and only on the `on` / `off` states. Registration happens during the
 plugin's `plugins_loaded` init (priority 10), before the mu-plugin loader
 evaluates the filter at `PHP_INT_MAX`.
+
+## Enable vs. disable (important)
+
+WP Cloud's *enablement* comes from the loader's tiers (the constant, a platform
+define, and the client-level percentage rollout). The
+`wpcloud_bot_protection_enable` filter this module drives is an **override**
+layered on top — and in the currently deployed loader that override reliably
+**disables** but does **not enable**. Verified in a live WP Cloud environment:
+
+| `WPC_BOT_PROTECTION_ENABLED` | Atlantis `state` | Result                  |
+| ---------------------------- | ---------------- | ----------------------- |
+| `true`                       | `inherit`        | on                      |
+| `true`                       | `on`             | on                      |
+| `true`                       | `off`            | **off** (override wins) |
+| absent / `false`             | `on`             | **off** (no arming tier)|
+
+So:
+
+- **To disable a site — use `off`.** This is the module's primary, reliable
+  job: the per-site "escape hatch", including exempting automation/test sites.
+- **To enable a site — set `WPC_BOT_PROTECTION_ENABLED = true`** (or have the
+  client enabled via the platform percentage rollout). `on` alone cannot arm a
+  site that no tier has enabled.
+
+In short: `off` is the dependable lever, `inherit` respects the platform
+decision, and `on` means "force-on where the loader is already armed."
 
 ## WP Cloud precondition
 

--- a/src/Modules/BotProtection/README.md
+++ b/src/Modules/BotProtection/README.md
@@ -61,9 +61,15 @@ that has not yet received the mu-plugin — nothing listens on the filter, so
 ## WP-CLI
 
 ```sh
-wp atlantis bot-protection status
-wp atlantis bot-protection set <inherit|off>
+wp atlantis module bot-protection status
+wp atlantis module bot-protection set <inherit|off>
 ```
+
+These live under `wp atlantis module` (not as a top-level command): the
+`state` is module configuration, a sibling of `module activate`/`deactivate`.
+Note that `wp atlantis module status bot-protection` (generic module status)
+and `wp atlantis module bot-protection status` (the state-specific view) are
+distinct commands with different output.
 
 ## Status endpoint
 

--- a/src/Modules/BotProtection/README.md
+++ b/src/Modules/BotProtection/README.md
@@ -55,6 +55,22 @@ So:
 In short: `off` is the dependable lever, `inherit` respects the platform
 decision, and `on` means "force-on where the loader is already armed."
 
+## Non-production environments
+
+On any environment where `wp_get_environment_type()` is not `production`,
+protection is **forced off** unless the state is explicitly `on`. Staging and
+development sites routinely run login automation — CI/e2e suites, uptime and
+synthetic-login monitors, scripted provisioning — that bot protection would
+challenge or block, so this keeps those sites clear by default (mirroring the
+Tracking module's production gating).
+
+- non-production + `inherit` or `off` → forced off
+- non-production + `on` → on (deliberate opt-in, e.g. to test protection)
+- production → states behave as described above
+
+The determination is filterable via `a8csp_atlantis_bot_protection_is_production`
+(return `true`/`false`) for sites where the environment type isn't set reliably.
+
 ## WP Cloud precondition
 
 The mu-plugin only loads where the WP Cloud credentials `ATOMIC_SITE_ID` and
@@ -76,6 +92,8 @@ wp atlantis bot-protection set <inherit|on|off>
 - `state` — `inherit` / `on` / `off`. The authoritative enforcement signal.
 - `wp_cloud` — whether the WP Cloud credentials are present.
 - `mu_plugin_present` — whether the mu-plugin is loaded.
+- `environment` — the site's environment type; non-production forces protection
+  off unless `state` is `on`.
 
 The shared `enabled` field is always `true` for this mandatory module and does
 not indicate enforcement; read `state` instead.

--- a/src/Modules/BotProtection/index.php
+++ b/src/Modules/BotProtection/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -156,7 +156,11 @@ class Plugin {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			\WP_CLI::add_command( 'atlantis module', Module_Command::class );
 			\WP_CLI::add_command( 'atlantis message', Message_Command::class );
-			\WP_CLI::add_command( 'atlantis bot-protection', BotProtection_Command::class );
+			// Nested under `module`: bot-protection's `state` is module
+			// configuration (a sibling of activate/deactivate), so it lives with
+			// the module registry rather than as a top-level command. Registered
+			// after the parent `atlantis module` so the composite command exists.
+			\WP_CLI::add_command( 'atlantis module bot-protection', BotProtection_Command::class );
 		}
 	}
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2,6 +2,7 @@
 
 namespace A8C\SpecialProjects\Atlantis;
 
+use A8C\SpecialProjects\Atlantis\CLI\BotProtection_Command;
 use A8C\SpecialProjects\Atlantis\CLI\Message_Command;
 use A8C\SpecialProjects\Atlantis\CLI\Module_Command;
 use A8C\SpecialProjects\Atlantis\REST\Status_Controller;
@@ -155,6 +156,7 @@ class Plugin {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			\WP_CLI::add_command( 'atlantis module', Module_Command::class );
 			\WP_CLI::add_command( 'atlantis message', Message_Command::class );
+			\WP_CLI::add_command( 'atlantis bot-protection', BotProtection_Command::class );
 		}
 	}
 

--- a/src/REST/Status_Controller.php
+++ b/src/REST/Status_Controller.php
@@ -120,6 +120,7 @@ class Status_Controller {
 			$modules['bot-protection']['state']             = BotProtection::get_configured_state();
 			$modules['bot-protection']['wp_cloud']          = BotProtection::is_wp_cloud();
 			$modules['bot-protection']['mu_plugin_present'] = BotProtection::is_mu_plugin_present();
+			$modules['bot-protection']['environment']       = \function_exists( 'wp_get_environment_type' ) ? \wp_get_environment_type() : 'production';
 		}
 
 		return \rest_ensure_response(

--- a/src/REST/Status_Controller.php
+++ b/src/REST/Status_Controller.php
@@ -114,8 +114,8 @@ class Status_Controller {
 
 		// Bot Protection is mandatory, so its shared `enabled` flag (from
 		// is_active(), set above) is always true and does NOT indicate whether
-		// protection is being forced. `state` (inherit|on|off) is the
-		// authoritative enforcement signal — fleet tooling should read that.
+		// protection is being forced. `state` (inherit|off) is the authoritative
+		// enforcement signal — fleet tooling should read that.
 		if ( isset( $modules['bot-protection'] ) ) {
 			$modules['bot-protection']['state']             = BotProtection::get_configured_state();
 			$modules['bot-protection']['wp_cloud']          = BotProtection::is_wp_cloud();

--- a/src/REST/Status_Controller.php
+++ b/src/REST/Status_Controller.php
@@ -3,6 +3,7 @@
 namespace A8C\SpecialProjects\Atlantis\REST;
 
 use A8C\SpecialProjects\Atlantis\Message_Query;
+use A8C\SpecialProjects\Atlantis\Modules\BotProtection\BotProtection;
 use A8C\SpecialProjects\Atlantis\Modules\Messages\CustomTable;
 use A8C\SpecialProjects\Atlantis\Plugin;
 
@@ -109,6 +110,12 @@ class Status_Controller {
 
 		if ( isset( $modules['messages'] ) ) {
 			$modules['messages']['count'] = $this->count_messages();
+		}
+
+		if ( isset( $modules['bot-protection'] ) ) {
+			$modules['bot-protection']['state']             = BotProtection::get_configured_state();
+			$modules['bot-protection']['wp_cloud']          = BotProtection::is_wp_cloud();
+			$modules['bot-protection']['mu_plugin_present'] = BotProtection::is_mu_plugin_present();
 		}
 
 		return \rest_ensure_response(

--- a/src/REST/Status_Controller.php
+++ b/src/REST/Status_Controller.php
@@ -120,7 +120,7 @@ class Status_Controller {
 			$modules['bot-protection']['state']             = BotProtection::get_configured_state();
 			$modules['bot-protection']['wp_cloud']          = BotProtection::is_wp_cloud();
 			$modules['bot-protection']['mu_plugin_present'] = BotProtection::is_mu_plugin_present();
-			$modules['bot-protection']['environment']       = \function_exists( 'wp_get_environment_type' ) ? \wp_get_environment_type() : 'production';
+			$modules['bot-protection']['environment']       = \wp_get_environment_type();
 		}
 
 		return \rest_ensure_response(

--- a/src/REST/Status_Controller.php
+++ b/src/REST/Status_Controller.php
@@ -112,6 +112,10 @@ class Status_Controller {
 			$modules['messages']['count'] = $this->count_messages();
 		}
 
+		// Bot Protection is mandatory, so its shared `enabled` flag (from
+		// is_active(), set above) is always true and does NOT indicate whether
+		// protection is being forced. `state` (inherit|on|off) is the
+		// authoritative enforcement signal — fleet tooling should read that.
 		if ( isset( $modules['bot-protection'] ) ) {
 			$modules['bot-protection']['state']             = BotProtection::get_configured_state();
 			$modules['bot-protection']['wp_cloud']          = BotProtection::is_wp_cloud();

--- a/tests/Integration/BotProtectionTestCest.php
+++ b/tests/Integration/BotProtectionTestCest.php
@@ -54,25 +54,13 @@ class BotProtectionTestCest {
 				update_option( $option_name, array( 'state' => 'bogus' ) );
 				Assert::assertSame( BotProtection::STATE_INHERIT, BotProtection::get_configured_state() );
 
+				// The removed `on` value is no longer valid and falls back too.
+				update_option( $option_name, array( 'state' => 'on' ) );
+				Assert::assertSame( BotProtection::STATE_INHERIT, BotProtection::get_configured_state() );
+
 				// A malformed (non-string) value must not trigger a string cast.
 				update_option( $option_name, array( 'state' => array( 'not', 'a', 'string' ) ) );
 				Assert::assertSame( BotProtection::STATE_INHERIT, BotProtection::get_configured_state() );
-			}
-		);
-	}
-
-	/**
-	 * The `on` state forces the filter to return true.
-	 *
-	 * @param IntegrationTester $i Tester instance.
-	 *
-	 * @return void
-	 */
-	public function on_state_forces_filter_true( IntegrationTester $i ): void {
-		$this->with_state(
-			BotProtection::STATE_ON,
-			static function (): void {
-				Assert::assertTrue( apply_filters( self::FILTER, false ) );
 			}
 		);
 	}
@@ -110,14 +98,14 @@ class BotProtectionTestCest {
 	}
 
 	/**
-	 * On non-production environments, protection is forced off unless the state
-	 * is explicitly `on`.
+	 * On non-production environments, protection is forced off regardless of the
+	 * stored state.
 	 *
 	 * @param IntegrationTester $i Tester instance.
 	 *
 	 * @return void
 	 */
-	public function non_production_forces_off_unless_on( IntegrationTester $i ): void {
+	public function non_production_forces_off( IntegrationTester $i ): void {
 		// `inherit` on non-production forces off instead of deferring.
 		$this->with_state(
 			BotProtection::STATE_INHERIT,
@@ -132,15 +120,6 @@ class BotProtectionTestCest {
 			BotProtection::STATE_OFF,
 			static function (): void {
 				Assert::assertFalse( apply_filters( self::FILTER, true ) );
-			},
-			false
-		);
-
-		// Explicit `on` still wins on non-production (deliberate opt-in).
-		$this->with_state(
-			BotProtection::STATE_ON,
-			static function (): void {
-				Assert::assertTrue( apply_filters( self::FILTER, false ) );
 			},
 			false
 		);
@@ -160,15 +139,18 @@ class BotProtectionTestCest {
 		$this->restore_option(
 			$option_name,
 			static function (): void {
-				Assert::assertTrue( BotProtection::set_state( BotProtection::STATE_ON ) );
-				Assert::assertSame( BotProtection::STATE_ON, BotProtection::get_configured_state() );
+				Assert::assertTrue( BotProtection::set_state( BotProtection::STATE_OFF ) );
+				Assert::assertSame( BotProtection::STATE_OFF, BotProtection::get_configured_state() );
 
-				$result = BotProtection::set_state( 'nonsense' );
-				Assert::assertInstanceOf( WP_Error::class, $result );
-				Assert::assertSame( 'a8csp_atlantis_invalid_bot_protection_state', $result->get_error_code() );
+				// The removed `on` value is rejected like any other invalid input.
+				foreach ( array( 'on', 'nonsense' ) as $invalid ) {
+					$result = BotProtection::set_state( $invalid );
+					Assert::assertInstanceOf( WP_Error::class, $result );
+					Assert::assertSame( 'a8csp_atlantis_invalid_bot_protection_state', $result->get_error_code() );
+				}
 
-				// The rejected write left the prior value intact.
-				Assert::assertSame( BotProtection::STATE_ON, BotProtection::get_configured_state() );
+				// The rejected writes left the prior value intact.
+				Assert::assertSame( BotProtection::STATE_OFF, BotProtection::get_configured_state() );
 			}
 		);
 	}
@@ -225,7 +207,6 @@ class BotProtectionTestCest {
 					try {
 						$assertions();
 					} finally {
-						remove_filter( self::FILTER, '__return_true', PHP_INT_MAX );
 						remove_filter( self::FILTER, '__return_false', PHP_INT_MAX );
 					}
 				}

--- a/tests/Integration/BotProtectionTestCest.php
+++ b/tests/Integration/BotProtectionTestCest.php
@@ -98,34 +98,6 @@ class BotProtectionTestCest {
 	}
 
 	/**
-	 * On non-production environments, protection is forced off regardless of the
-	 * stored state.
-	 *
-	 * @param IntegrationTester $i Tester instance.
-	 *
-	 * @return void
-	 */
-	public function non_production_forces_off( IntegrationTester $i ): void {
-		// `inherit` on non-production forces off instead of deferring.
-		$this->with_state(
-			BotProtection::STATE_INHERIT,
-			static function (): void {
-				Assert::assertFalse( apply_filters( self::FILTER, true ) );
-			},
-			false
-		);
-
-		// `off` on non-production stays off.
-		$this->with_state(
-			BotProtection::STATE_OFF,
-			static function (): void {
-				Assert::assertFalse( apply_filters( self::FILTER, true ) );
-			},
-			false
-		);
-	}
-
-	/**
 	 * set_state() persists a valid state and rejects an invalid one without
 	 * clobbering the stored value.
 	 *
@@ -185,35 +157,29 @@ class BotProtectionTestCest {
 	 *
 	 * @return void
 	 */
-	private function with_state( string $state, callable $assertions, bool $is_production = true ): void {
+	private function with_state( string $state, callable $assertions ): void {
 		$option_name = a8csp_atlantis_generate_module_settings_key( 'Bot Protection' );
-		$prod_filter = static fn(): bool => $is_production;
-		add_filter( 'a8csp_atlantis_bot_protection_is_production', $prod_filter );
 
-		try {
-			$this->restore_option(
-				$option_name,
-				function () use ( $state, $assertions, $option_name ): void {
-					update_option(
-						$option_name,
-						array(
-							'enabled' => '1',
-							'state'   => $state,
-						)
-					);
+		$this->restore_option(
+			$option_name,
+			function () use ( $state, $assertions, $option_name ): void {
+				update_option(
+					$option_name,
+					array(
+						'enabled' => '1',
+						'state'   => $state,
+					)
+				);
 
-					( new BotProtection() )->maybe_initialize();
+				( new BotProtection() )->maybe_initialize();
 
-					try {
-						$assertions();
-					} finally {
-						remove_filter( self::FILTER, '__return_false', PHP_INT_MAX );
-					}
+				try {
+					$assertions();
+				} finally {
+					remove_filter( self::FILTER, '__return_false', PHP_INT_MAX );
 				}
-			);
-		} finally {
-			remove_filter( 'a8csp_atlantis_bot_protection_is_production', $prod_filter );
-		}
+			}
+		);
 	}
 
 	/**

--- a/tests/Integration/BotProtectionTestCest.php
+++ b/tests/Integration/BotProtectionTestCest.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Integration tests for the Bot Protection module.
+ */
+
+declare(strict_types=1);
+
+use A8C\SpecialProjects\Atlantis\Modules\BotProtection\BotProtection;
+use PHPUnit\Framework\Assert;
+use Tests\Support\IntegrationTester;
+
+/**
+ * Bot Protection module integration tests.
+ */
+class BotProtectionTestCest {
+	/**
+	 * The WP Cloud filter the module drives.
+	 *
+	 * @var string
+	 */
+	private const FILTER = 'wpcloud_bot_protection_enable';
+
+	/**
+	 * Module metadata remains stable and the module is mandatory.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function module_metadata_is_stable( IntegrationTester $i ): void {
+		$module = new BotProtection();
+
+		Assert::assertSame( 'Bot Protection', $module->get_name() );
+		Assert::assertTrue( $module->is_mandatory() );
+	}
+
+	/**
+	 * get_configured_state() falls back to inherit for unset, unknown, or
+	 * non-string stored values.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function get_configured_state_falls_back_to_inherit( IntegrationTester $i ): void {
+		$option_name = a8csp_atlantis_generate_module_settings_key( 'Bot Protection' );
+
+		$this->restore_option(
+			$option_name,
+			function () use ( $option_name ): void {
+				delete_option( $option_name );
+				Assert::assertSame( BotProtection::STATE_INHERIT, BotProtection::get_configured_state() );
+
+				update_option( $option_name, array( 'state' => 'bogus' ) );
+				Assert::assertSame( BotProtection::STATE_INHERIT, BotProtection::get_configured_state() );
+
+				// A malformed (non-string) value must not trigger a string cast.
+				update_option( $option_name, array( 'state' => array( 'not', 'a', 'string' ) ) );
+				Assert::assertSame( BotProtection::STATE_INHERIT, BotProtection::get_configured_state() );
+			}
+		);
+	}
+
+	/**
+	 * The `on` state forces the filter to return true.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function on_state_forces_filter_true( IntegrationTester $i ): void {
+		$this->with_state(
+			BotProtection::STATE_ON,
+			static function (): void {
+				Assert::assertTrue( apply_filters( self::FILTER, false ) );
+			}
+		);
+	}
+
+	/**
+	 * The `off` state forces the filter to return false.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function off_state_forces_filter_false( IntegrationTester $i ): void {
+		$this->with_state(
+			BotProtection::STATE_OFF,
+			static function (): void {
+				Assert::assertFalse( apply_filters( self::FILTER, true ) );
+			}
+		);
+	}
+
+	/**
+	 * The `inherit` state registers no filter and leaves the value untouched.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function inherit_state_registers_no_filter( IntegrationTester $i ): void {
+		$this->with_state(
+			BotProtection::STATE_INHERIT,
+			static function (): void {
+				Assert::assertSame( 'sentinel', apply_filters( self::FILTER, 'sentinel' ) );
+			}
+		);
+	}
+
+	/**
+	 * set_state() persists a valid state and rejects an invalid one without
+	 * clobbering the stored value.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function set_state_validates_and_persists( IntegrationTester $i ): void {
+		$option_name = a8csp_atlantis_generate_module_settings_key( 'Bot Protection' );
+
+		$this->restore_option(
+			$option_name,
+			static function (): void {
+				Assert::assertTrue( BotProtection::set_state( BotProtection::STATE_ON ) );
+				Assert::assertSame( BotProtection::STATE_ON, BotProtection::get_configured_state() );
+
+				$result = BotProtection::set_state( 'nonsense' );
+				Assert::assertInstanceOf( WP_Error::class, $result );
+				Assert::assertSame( 'a8csp_atlantis_invalid_bot_protection_state', $result->get_error_code() );
+
+				// The rejected write left the prior value intact.
+				Assert::assertSame( BotProtection::STATE_ON, BotProtection::get_configured_state() );
+			}
+		);
+	}
+
+	/**
+	 * The mandatory module refuses to be disabled.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function mandatory_module_refuses_disable( IntegrationTester $i ): void {
+		$option_name = a8csp_atlantis_generate_module_settings_key( 'Bot Protection' );
+
+		$this->restore_option(
+			$option_name,
+			static function (): void {
+				$result = ( new BotProtection() )->set_enabled( false );
+
+				Assert::assertInstanceOf( WP_Error::class, $result );
+				Assert::assertSame( 'a8csp_atlantis_mandatory_module', $result->get_error_code() );
+			}
+		);
+	}
+
+	/**
+	 * Initializes a fresh module at the given state, runs the assertions, then
+	 * removes any filter it registered and restores the option.
+	 *
+	 * @param string   $state      One of the STATE_* constants.
+	 * @param callable $assertions Assertions to run while the module is active.
+	 *
+	 * @return void
+	 */
+	private function with_state( string $state, callable $assertions ): void {
+		$option_name = a8csp_atlantis_generate_module_settings_key( 'Bot Protection' );
+
+		$this->restore_option(
+			$option_name,
+			function () use ( $state, $assertions, $option_name ): void {
+				update_option(
+					$option_name,
+					array(
+						'enabled' => '1',
+						'state'   => $state,
+					)
+				);
+
+				( new BotProtection() )->maybe_initialize();
+
+				try {
+					$assertions();
+				} finally {
+					remove_filter( self::FILTER, '__return_true', PHP_INT_MAX );
+					remove_filter( self::FILTER, '__return_false', PHP_INT_MAX );
+				}
+			}
+		);
+	}
+
+	/**
+	 * Saves the option, runs the callback, and restores the original value.
+	 *
+	 * @param string   $option_name Option name to back up.
+	 * @param callable $callback    Callback to run while the option is mutated.
+	 *
+	 * @return void
+	 */
+	private function restore_option( string $option_name, callable $callback ): void {
+		$original = get_option( $option_name, null );
+		try {
+			$callback();
+		} finally {
+			if ( null === $original ) {
+				delete_option( $option_name );
+			} else {
+				update_option( $option_name, $original );
+			}
+		}
+	}
+}

--- a/tests/Integration/BotProtectionTestCest.php
+++ b/tests/Integration/BotProtectionTestCest.php
@@ -110,6 +110,43 @@ class BotProtectionTestCest {
 	}
 
 	/**
+	 * On non-production environments, protection is forced off unless the state
+	 * is explicitly `on`.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function non_production_forces_off_unless_on( IntegrationTester $i ): void {
+		// `inherit` on non-production forces off instead of deferring.
+		$this->with_state(
+			BotProtection::STATE_INHERIT,
+			static function (): void {
+				Assert::assertFalse( apply_filters( self::FILTER, true ) );
+			},
+			false
+		);
+
+		// `off` on non-production stays off.
+		$this->with_state(
+			BotProtection::STATE_OFF,
+			static function (): void {
+				Assert::assertFalse( apply_filters( self::FILTER, true ) );
+			},
+			false
+		);
+
+		// Explicit `on` still wins on non-production (deliberate opt-in).
+		$this->with_state(
+			BotProtection::STATE_ON,
+			static function (): void {
+				Assert::assertTrue( apply_filters( self::FILTER, false ) );
+			},
+			false
+		);
+	}
+
+	/**
 	 * set_state() persists a valid state and rejects an invalid one without
 	 * clobbering the stored value.
 	 *
@@ -166,30 +203,36 @@ class BotProtectionTestCest {
 	 *
 	 * @return void
 	 */
-	private function with_state( string $state, callable $assertions ): void {
+	private function with_state( string $state, callable $assertions, bool $is_production = true ): void {
 		$option_name = a8csp_atlantis_generate_module_settings_key( 'Bot Protection' );
+		$prod_filter = static fn(): bool => $is_production;
+		add_filter( 'a8csp_atlantis_bot_protection_is_production', $prod_filter );
 
-		$this->restore_option(
-			$option_name,
-			function () use ( $state, $assertions, $option_name ): void {
-				update_option(
-					$option_name,
-					array(
-						'enabled' => '1',
-						'state'   => $state,
-					)
-				);
+		try {
+			$this->restore_option(
+				$option_name,
+				function () use ( $state, $assertions, $option_name ): void {
+					update_option(
+						$option_name,
+						array(
+							'enabled' => '1',
+							'state'   => $state,
+						)
+					);
 
-				( new BotProtection() )->maybe_initialize();
+					( new BotProtection() )->maybe_initialize();
 
-				try {
-					$assertions();
-				} finally {
-					remove_filter( self::FILTER, '__return_true', PHP_INT_MAX );
-					remove_filter( self::FILTER, '__return_false', PHP_INT_MAX );
+					try {
+						$assertions();
+					} finally {
+						remove_filter( self::FILTER, '__return_true', PHP_INT_MAX );
+						remove_filter( self::FILTER, '__return_false', PHP_INT_MAX );
+					}
 				}
-			}
-		);
+			);
+		} finally {
+			remove_filter( 'a8csp_atlantis_bot_protection_is_production', $prod_filter );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Implements [T51ENG-1996](https://linear.app/a8c/issue/T51ENG-1996/enable-wp-cloud-bot-protection-for-wp-cloud-sites) — Team 51 control plane for WP Cloud Bot Protection ("blackbox").

## Background

WP Cloud sites ship a `wpcloud-bot-protection` mu-plugin that gates the login and password-reset forms. Its loader was moved (per [the Bastion P2 request](https://bastionp2.wordpress.com/2026/06/29/blackbox-on-wp-cloud-implementation/), shipped 2026-07-21) from `muplugins_loaded` to `plugins_loaded` @ `PHP_INT_MAX`, and resolves enablement through a set of **tiers** — the per-site `WPC_BOT_PROTECTION_ENABLED` constant, a platform define, and the PR#15 client-level percentage rollout — with the `wpcloud_bot_protection_enable` filter as a per-request override:

```php
if ( ! apply_filters( 'wpcloud_bot_protection_enable', $default ) ) {
    return; // protection not loaded
}
```

**Verified live on WP Cloud:** in the currently deployed loader that filter reliably **disables** but does **not enable** — a site with no armed tier stays off no matter what the filter returns. So this module is a per-site **off-switch / override**, not an enabler. Enabling a site is done by arming a tier (set `WPC_BOT_PROTECTION_ENABLED = true`, or the client-level percentage rollout).

## What this adds

A **mandatory** `BotProtection` module with a single two-state control, `state`:

| `state` | Atlantis behavior | Effect |
|---|---|---|
| `inherit` *(default)* | registers nothing on the filter | WP Cloud's own tiers decide → **no-op on rollout, zero blast radius** |
| `off` | `add_filter( 'wpcloud_bot_protection_enable', '__return_false', PHP_INT_MAX )` | force **off** — a hard override, beats even a client-level rollout |

There is deliberately **no `on`**: because the deployed filter cannot enable a site that no tier has armed, an `on` would be indistinguishable from `inherit` in every real case and only invite confusion. To enable a site, arm a tier.

**Design choices:**
- **`PHP_INT_MAX` filter priority** → our verdict is the final say. Registered during init at `plugins_loaded` priority 10, before the mu-plugin loader evaluates it at `PHP_INT_MAX` — timing guaranteed.
- **Mandatory + single dropdown** → one unambiguous knob. Avoids the footgun where "disabling the module" silently reverts to WP Cloud's tiers instead of forcing off. The settings UI shows only the "Enforcement" dropdown (no Enabled checkbox).
- **Uniform across environments** → the `state` applies the same everywhere; staging/dev sites `inherit` by default like production. A non-production site that runs login automation and must stay clear is set to `off` explicitly (rather than gated on `wp_get_environment_type()`).
- **Safe everywhere** → the filter only exists where the mu-plugin does, so `off` is a no-op on Pressable/non-WP-Cloud sites (the settings screen and CLI surface a notice in that case).

## Control surfaces

**Settings UI** — Atlantis → Modules → Bot Protection → "Enforcement" dropdown (Inherit / Off).

**WP-CLI** (`wp atlantis bot-protection`, mirroring `wp atlantis module`):
- `status` — reports `state`, `wp_cloud` (creds present), `mu_plugin_present`, `environment` (informational), with `--field`/`--format` for scripting.
- `set <inherit|off>` — sets the enforcement state; warns when a force-off has no effect off WP Cloud or where the mu-plugin is absent.

**REST** (`GET /wp-json/a8csp-atlantis/v1/status`) — `modules.bot-protection` now includes `state`, `wp_cloud`, `mu_plugin_present`, and `environment`. `state` is the authoritative enforcement signal (the shared `enabled` flag is always true for this mandatory module).

`BotProtection::set_state()` is the shared, validated write path used by both the settings form and the CLI.

## Rollout posture

Per the decision to roll out safely (login/password-reset gating carries lock-out risk, and the P2 flags testing risk), this **ships default-`inherit` (off/no-op)** — shipping the module changes no behavior. `off` is the per-site kill switch for a partner who gets blocked; enablement remains a tier decision.

## Follow-up (separate)

- The **Team 51 CLI** fleet-wide orchestration (this PR is the in-plugin per-site control it drives).
- Support heads-up doc (how to disable when a partner is blocked), per the issue thread.
- Confirm with Bastion whether the deployed filter is intended to be disable-only, and whether an enable path via the filter is planned.

## Verification

- `phpcs` and `phpstan` — clean on all changed files.
- `phpmd` — no new *gating* issues; the one MissingImport on `new \WP_CLI\Formatter` matches the existing `Module_Command` pattern (phpmd is non-gating here — trunk already carries pre-existing findings).
- Behavior (inherit/off × armed/unarmed tier) verified live on a WP Cloud site.
- Autoloader regenerated; new classes confirmed in the classmap.

## Notes

- Ships in the **1.3.0** release (retargeted from 1.4.0). All four version sources — plugin header, `package.json`, `package-lock.json`, README — kept in sync for the `version-consistency` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

