### PR TITLE
docs: bump README version to 1.2.4 to match trunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Before publishing a release, update the version in:
 
 - `a8csp-atlantis.php`
 - `package.json`
+- `README.md` (the `Version:` line above)
 
 Run `composer generate-autoloader` if local development reports missing
 classmap-backed classes after changing generated/autoloaded PHP symbols.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Plugin metadata from `a8csp-atlantis.php`:
 
 - Plugin name: `A8CSP Atlantis`
 - Text domain: `a8csp-atlantis`
-- Version: `1.2.0`
+- Version: `1.2.4`
 - Requires WordPress: `6.8+`
 - Tested up to WordPress: `7.0`
 - Requires PHP: `8.2+`


### PR DESCRIPTION
## Summary

`README.md` metadata still listed the plugin version as `1.2.0` while the plugin header (`a8csp-atlantis.php`) and `package.json` are already at `1.2.4`. This syncs the README so all version sources agree ahead of the 1.2.4 release.

The README was never bumped across the 1.2.1 → 1.2.4 releases, so it had drifted behind.

## Version sources now in sync

| Source | Version |
|--------|---------|
| `a8csp-atlantis.php` header | `1.2.4` |
| `package.json` | `1.2.4` |
| `README.md` | `1.2.4` |

## Test plan

- [x] Docs-only change; no code or build impact
- [x] Verified all three version references match

🤖 Generated with [Claude Code](https://claude.com/claude-code)