### PR TITLE
ci: build release zip on pre-releases too

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -40,6 +40,24 @@ jobs:
           mkdir a8csp-atlantis
           cp -r a8csp-atlantis.php functions.php functions-bootstrap.php index.php LICENSE src includes assets languages models templates vendor a8csp-atlantis/
 
+      # Pre-release zips ship a plain `1.3.0` header (version-consistency.yml
+      # forbids a suffix in-repo), so a site that installs an RC would report
+      # the same version as the final release and the self-updater's
+      # `version_compare( Version, latest, '<' )` in a8csp-atlantis.php would
+      # never fire — stranding it on the RC. Stamp the tag (e.g. `1.3.0-rc1`)
+      # into the STAGED header only for pre-releases, so those sites upgrade to
+      # the final build. Full releases are untouched.
+      - name: Stamp pre-release version into staged header
+        if: ${{ github.event.release.prerelease }}
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${TAG_NAME#v}"
+          export VERSION
+          perl -i -pe 's|^(\s*\* Version:\s+).*|${1}$ENV{VERSION}|' a8csp-atlantis/a8csp-atlantis.php
+          echo "Stamped pre-release version into staged header: ${VERSION}"
+          grep -m1 -E '^\s*\* Version:' a8csp-atlantis/a8csp-atlantis.php
+
       - name: Zip Release
         run: |
           zip -r ${{ github.event.repository.name }}.zip ./a8csp-atlantis

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,8 +1,11 @@
 name: Build and Release
 
 on:
+  # `published` fires once for every release publish — full releases AND
+  # pre-releases (e.g. `v1.3.0-rc1`). The previous `released` filter skipped
+  # pre-releases, so RC tags never produced a build/zip.
   release:
-    types: [ released ]
+    types: [ published ]
 
 jobs:
   build:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -55,8 +55,13 @@ jobs:
           VERSION="${TAG_NAME#v}"
           export VERSION
           perl -i -pe 's|^(\s*\* Version:\s+).*|${1}$ENV{VERSION}|' a8csp-atlantis/a8csp-atlantis.php
-          echo "Stamped pre-release version into staged header: ${VERSION}"
-          grep -m1 -E '^\s*\* Version:' a8csp-atlantis/a8csp-atlantis.php
+          stamped="$(grep -m1 -E '^\s*\* Version:' a8csp-atlantis/a8csp-atlantis.php)"
+          echo "Header now: ${stamped}"
+          # Fail loudly if the substitution matched nothing (e.g. the header line
+          # was reformatted) — perl -pe exits 0 on no match, which would ship an
+          # unstamped RC zip silently.
+          printf '%s' "$stamped" | grep -qF -- "$VERSION" \
+            || { echo "::error::Failed to stamp pre-release version '${VERSION}' into the plugin header."; exit 1; }
 
       - name: Zip Release
         run: |
@@ -66,3 +71,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ github.event.repository.name }}.zip
+          # Preserve the triggering release's pre-release flag. Without this the
+          # action could un-mark a pre-release when attaching the asset, which
+          # would expose an RC through `/releases/latest` and auto-update sites
+          # onto it — exactly what the pre-release label is meant to prevent.
+          prerelease: ${{ github.event.release.prerelease }}


### PR DESCRIPTION
## Problem

The **Build and Release** workflow triggered on:

```yaml
on:
  release:
    types: [ released ]
```

GitHub fires the `released` action only for **full** releases (or when a pre-release is promoted to a full release). Publishing a **pre-release** — e.g. `v1.3.0-rc1` — emits the `prereleased` action instead, which this workflow didn't listen for. Result: no Actions ran, and no zip asset was attached to the RC.

## Fix

Switch the trigger to `published`, which fires **once for every release publish — full releases and pre-releases alike**:

```yaml
on:
  release:
    types: [ published ]
```

Now RC tags produce a build/zip like full releases do. `published` fires a single time per publish (no double-build for full releases), and the existing `softprops/action-gh-release` step uploads the asset to whichever release triggered it, so pre-releases get their zip attached.

## Note

This does not retroactively build the existing `v1.3.0-rc1` (the workflow change only affects future publishes). To get a zip on rc1, re-publish it or cut a new RC after this merges — or attach a locally-built zip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: pre-release version stamping (addresses Poseidon)

Enabling pre-release builds surfaced a stranding bug. The in-repo header is a plain `1.3.0` (`version-consistency.yml` forbids a `-rc1` suffix), so a site that installs an RC zip reports the *same* version as the final release. The self-updater's `version_compare( $plugin_data['Version'], $latest_release_version, '<' )` (`a8csp-atlantis.php:93`, latest fetched from `/releases/latest`) would then be false when `v1.3.0` ships, stranding the site on the RC.

Fix: a `build`-job step that, **only when `github.event.release.prerelease` is true**, rewrites the *staged* copy's ` * Version:` header to the tag (e.g. `1.3.0-rc1`) before zipping. Full releases are untouched; the repo source is untouched. `version_compare('1.3.0-rc1','1.3.0','<')` is `true`, so RC sites upgrade to the final build.
