### PR TITLE
fix: prevent duplicate encryption-key define in shared wp-config (multisite)

### DIFF
--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -98,8 +98,17 @@ class Encryption {
 			// line ever ends up in the file (e.g. a platform-managed config
 			// re-merge), PHP won't emit an "already defined" warning.
 			$to_insert = "if ( ! defined( 'A8CSP_ATLANTIS_ENCRYPTION_KEY' ) ) { define( 'A8CSP_ATLANTIS_ENCRYPTION_KEY', '" . \addcslashes( $encryption_key, "\\'" ) . "' ); }\r\n";
-			if ( \str_contains( $wp_config_contents, "/* That's all, stop editing!" ) ) {
-				$wp_config_contents = \str_replace( "/* That's all, stop editing!", $to_insert . "/* That's all, stop editing!", $wp_config_contents );
+
+			// Insert before the FIRST "stop editing" marker only. Some configs
+			// (notably multisite installs) carry more than one such marker; a
+			// naive str_replace() would write the define before every marker and
+			// create the exact duplicate-define warnings this method guards
+			// against. substr_replace() with a zero-length span inserts at the
+			// first match without touching the rest.
+			$marker    = "/* That's all, stop editing!";
+			$marker_at = \strpos( $wp_config_contents, $marker );
+			if ( false !== $marker_at ) {
+				$wp_config_contents = \substr_replace( $wp_config_contents, $to_insert, $marker_at, 0 );
 			} else {
 				$wp_config_contents = \preg_replace( '/<\?php/', "<?php\r\n" . $to_insert, $wp_config_contents, 1 );
 			}

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -44,7 +44,17 @@ class Encryption {
 	 * @return  void
 	 */
 	public function maybe_auto_insert_encryption_key(): void {
-		if ( a8csp_atlantis_has_encryption_key() || 'yes' === get_option( 'a8csp_atlantis_inserted_encryption_key', 'no' ) ) {
+		if ( a8csp_atlantis_has_encryption_key() || 'yes' === $this->get_inserted_encryption_key_flag() ) {
+			return;
+		}
+
+		// On multisite, wp-config.php is a single file shared by the entire
+		// network. Only the main site writes to it, so subsites don't each
+		// append their own define() into the shared file (which produces
+		// "Constant ... already defined" warnings). The flag above is stored
+		// network-wide on multisite, so once the main site inserts the key
+		// every subsite short-circuits at the check above.
+		if ( is_multisite() && ! is_main_site() ) {
 			return;
 		}
 
@@ -74,7 +84,20 @@ class Encryption {
 
 		$success = false;
 		if ( \is_string( $wp_config_path ) && \is_string( $wp_config_contents ) ) {
-			$to_insert = "define( 'A8CSP_ATLANTIS_ENCRYPTION_KEY', '" . \addcslashes( $encryption_key, "\\'" ) . "' );\r\n";
+			// Idempotency guard: if the file already contains our define, don't
+			// append another. This covers the window where a prior request wrote
+			// the line but the constant isn't defined yet in the current runtime
+			// (stale include/opcache), or a race across concurrent requests. Just
+			// record the flag and bail rather than writing a duplicate.
+			if ( \str_contains( $wp_config_contents, 'A8CSP_ATLANTIS_ENCRYPTION_KEY' ) ) {
+				$this->mark_encryption_key_inserted();
+				return;
+			}
+
+			// Wrap the define in a defined() guard so that even if a duplicate
+			// line ever ends up in the file (e.g. a platform-managed config
+			// re-merge), PHP won't emit an "already defined" warning.
+			$to_insert = "if ( ! defined( 'A8CSP_ATLANTIS_ENCRYPTION_KEY' ) ) { define( 'A8CSP_ATLANTIS_ENCRYPTION_KEY', '" . \addcslashes( $encryption_key, "\\'" ) . "' ); }\r\n";
 			if ( \str_contains( $wp_config_contents, "/* That's all, stop editing!" ) ) {
 				$wp_config_contents = \str_replace( "/* That's all, stop editing!", $to_insert . "/* That's all, stop editing!", $wp_config_contents );
 			} else {
@@ -84,7 +107,7 @@ class Encryption {
 			if ( \is_string( $wp_config_contents ) && true === $wp_filesystem?->put_contents( $wp_config_path, $wp_config_contents, FS_CHMOD_FILE ) ) {
 				$success = true;
 
-				update_option( 'a8csp_atlantis_inserted_encryption_key', 'yes' );
+				$this->mark_encryption_key_inserted();
 				if ( function_exists( 'opcache_invalidate' ) ) {
 					// Invalidate the opcode cache to ensure the new key is used immediately.
 					opcache_invalidate( $wp_config_path, true );
@@ -102,7 +125,7 @@ class Encryption {
 						a8csp_atlantis_get_plugin_metadata( 'Name' ),
 						a8csp_atlantis_get_plugin_metadata( 'Version' )
 					) . '</p>';
-					$error .= '<p style="overflow: scroll">' . "<code>define( 'A8CSP_ATLANTIS_ENCRYPTION_KEY', '" . $encryption_key . "' );</code></p>";
+					$error .= '<p style="overflow: scroll">' . "<code>if ( ! defined( 'A8CSP_ATLANTIS_ENCRYPTION_KEY' ) ) { define( 'A8CSP_ATLANTIS_ENCRYPTION_KEY', '" . $encryption_key . "' ); }</code></p>";
 
 					wp_admin_notice(
 						$error,
@@ -119,6 +142,41 @@ class Encryption {
 	// endregion
 
 	// region HELPERS
+
+	/**
+	 * Returns whether the encryption key has already been inserted into
+	 * wp-config.php.
+	 *
+	 * On multisite the flag is stored network-wide because wp-config.php is a
+	 * single file shared by every site in the network — tracking it per-site
+	 * would let each subsite conclude it still needs to insert the key.
+	 *
+	 * @since   1.3.1
+	 * @version 1.3.1
+	 *
+	 * @return  string
+	 */
+	private function get_inserted_encryption_key_flag(): string {
+		return is_multisite()
+			? (string) get_site_option( 'a8csp_atlantis_inserted_encryption_key', 'no' )
+			: (string) get_option( 'a8csp_atlantis_inserted_encryption_key', 'no' );
+	}
+
+	/**
+	 * Records that the encryption key has been inserted into wp-config.php.
+	 *
+	 * @since   1.3.1
+	 * @version 1.3.1
+	 *
+	 * @return  void
+	 */
+	private function mark_encryption_key_inserted(): void {
+		if ( is_multisite() ) {
+			update_site_option( 'a8csp_atlantis_inserted_encryption_key', 'yes' );
+		} else {
+			update_option( 'a8csp_atlantis_inserted_encryption_key', 'yes' );
+		}
+	}
 
 	/**
 	 * Returns the path to the wp-config.php file.


### PR DESCRIPTION
## Problem

On multisite sites (e.g. `archive.blogs.harvard.edu`) we're seeing repeated PHP warnings:

```
PHP Warning: Constant A8CSP_ATLANTIS_ENCRYPTION_KEY already defined in /srv/htdocs/wp-config.php on line 94
```

`wp-config.php` ends up with **two** `define( 'A8CSP_ATLANTIS_ENCRYPTION_KEY', ... )` lines.

## Root cause

`Encryption::maybe_auto_insert_encryption_key()` gated only on:
1. the runtime `defined( 'A8CSP_ATLANTIS_ENCRYPTION_KEY' )` check, and
2. a **per-site** option (`get_option`/`update_option`).

On multisite, `wp-config.php` is a **single file shared by the entire network**, but the "have I already inserted?" flag was tracked per-subsite. So each active subsite independently concluded it still needed to insert the key. Combined with the runtime window where `defined()` is still `false` (a request that loaded `wp-config.php` before the line existed, or opcache lag), multiple subsites appended their own `define()` into the one shared file.

There was also no check of the **file contents** before appending — only the "stop editing" marker was matched.

## Fix (this PR)

1. **Idempotency guard** — before splicing, bail (and record the flag) if the file text already contains `A8CSP_ATLANTIS_ENCRYPTION_KEY`. Closes the stale-runtime / opcache / concurrent-request window.
2. **Self-healing define** — the inserted line is now wrapped in `if ( ! defined( 'A8CSP_ATLANTIS_ENCRYPTION_KEY' ) ) { define( ... ); }`, so even a stray duplicate (e.g. a platform-managed config re-merge) can't emit a warning. The manual-fallback admin notice was updated to match.
3. **Network-aware flag** — the "already inserted" flag is stored with `get_site_option`/`update_site_option` on multisite, and only the **main site** writes to the shared `wp-config.php` (`is_multisite() && ! is_main_site()` short-circuit).

## Not covered here

- The `WPCOMSP_BILMUR_PROVIDER` "already defined" warning on the same file is **platform-owned** — Atlantis only ever *reads* that constant (it's injected into `wp-config.php` by WP Cloud). Its duplication points to a doubled platform-managed block and should be raised with the hosting/Systems team. Atlantis's full-file rewrite of `wp-config.php` is the most likely trigger for disturbing that block; a longer-term option (not in this PR) is to stop hand-editing `wp-config.php` on managed hosts entirely.
- Existing affected sites still need their `wp-config.php` de-duplicated once (one-time cleanup); this PR prevents recurrence.

## Testing

- `php -l`, `phpcs`, and `phpstan` pass clean on `src/Encryption.php` (remaining phpstan findings are pre-existing in other files).
- The wp-config write path is environment-dependent and has no existing integration coverage in the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)