### PR TITLE
fix: clean up plugin data on uninstall

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Prepare Release Directory
         run: |
           mkdir a8csp-atlantis
-          cp -r a8csp-atlantis.php functions.php functions-bootstrap.php index.php LICENSE src includes assets languages models templates vendor a8csp-atlantis/
+          cp -r a8csp-atlantis.php functions.php functions-bootstrap.php index.php uninstall.php LICENSE src includes assets languages models templates vendor a8csp-atlantis/
 
       # Pre-release zips ship a plain `1.3.0` header (version-consistency.yml
       # forbids a suffix in-repo), so a site that installs an RC would report

--- a/tests/Integration/UninstallTestCest.php
+++ b/tests/Integration/UninstallTestCest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Integration tests for plugin uninstall cleanup.
+ *
+ * Mirrors what WordPress does when the plugin is deleted from
+ * Plugins -> Installed Plugins -> Delete.
+ */
+
+declare(strict_types=1);
+
+use A8C\SpecialProjects\Atlantis\Modules\Messages\CustomTable;
+use PHPUnit\Framework\Assert;
+use Tests\Support\IntegrationTester;
+
+/**
+ * Uninstall behaviour tests.
+ */
+class UninstallTestCest {
+	/**
+	 * Deleting the plugin must drop the messages table and remove every option it created.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function plugin_uninstall_drops_table_and_removes_options( IntegrationTester $i ): void {
+		$this->ensure_messages_table_exists();
+		$this->seed_plugin_state();
+
+		Assert::assertTrue( CustomTable::table_exists(), 'Precondition: messages table exists.' );
+		Assert::assertNotFalse( get_option( 'a8csp_atlantis_inserted_encryption_key' ), 'Precondition: encryption-key option exists.' );
+		Assert::assertNotFalse( get_option( 'plugin_update_delays' ), 'Precondition: delay option exists.' );
+
+		$this->run_uninstall();
+
+		Assert::assertFalse( CustomTable::table_exists(), 'Messages table should be dropped on uninstall.' );
+		Assert::assertFalse( get_option( 'a8csp_atlantis_inserted_encryption_key' ), 'Encryption-key option should be removed.' );
+		Assert::assertFalse( get_option( 'a8csp_atlantis_messages_schema_version' ), 'Schema-version option should be removed.' );
+		Assert::assertFalse( get_option( 'plugin_update_delays' ), 'plugin_update_delays should be removed.' );
+
+		foreach ( array( 'Tracking', 'Colophon', 'Messages', 'Autoupdates', 'Bot Protection' ) as $module_name ) {
+			$key = a8csp_atlantis_generate_module_settings_key( $module_name );
+			Assert::assertFalse( get_option( $key ), "Module option {$key} should be removed." );
+		}
+	}
+
+	/**
+	 * Ensure the messages table exists before the test runs uninstall.
+	 *
+	 * @return void
+	 */
+	private function ensure_messages_table_exists(): void {
+		if ( CustomTable::table_exists() ) {
+			return;
+		}
+
+		$table = new CustomTable();
+		$table->maybe_create_table();
+	}
+
+	/**
+	 * Seed the options and table state a real site would have.
+	 *
+	 * @return void
+	 */
+	private function seed_plugin_state(): void {
+		update_option( 'a8csp_atlantis_inserted_encryption_key', 'yes' );
+		update_option( 'a8csp_atlantis_messages_schema_version', '1.0.0' );
+		update_option( 'plugin_update_delays', array( 'delay' => 7 ) );
+
+		foreach ( array( 'Tracking', 'Colophon', 'Messages', 'Autoupdates', 'Bot Protection' ) as $module_name ) {
+			update_option( a8csp_atlantis_generate_module_settings_key( $module_name ), array( 'enabled' => '1' ) );
+		}
+	}
+
+	/**
+	 * Include the plugin's uninstall.php the same way WordPress core does on delete.
+	 *
+	 * @return void
+	 */
+	private function run_uninstall(): void {
+		if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+			define( 'WP_UNINSTALL_PLUGIN', 'a8csp-atlantis/a8csp-atlantis.php' );
+		}
+
+		$uninstall_file = constant( 'A8CSP_ATLANTIS_DIR_PATH' ) . 'uninstall.php';
+		Assert::assertFileExists( $uninstall_file, 'Plugin must ship an uninstall.php in its root.' );
+
+		include $uninstall_file;
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -6,9 +6,10 @@
  * (Plugins -> Installed Plugins -> Delete). Removes everything the plugin
  * created: the Messages custom table and every option it owns.
  *
- * The A8CSP_ATLANTIS_ENCRYPTION_KEY define is also stripped from wp-config.php
- * on a best-effort basis. Whether uninstall should rewrite wp-config.php at all
- * is the open question on the PR for https://github.com/a8cteam51/a8csp-atlantis/issues/80
+ * The A8CSP_ATLANTIS_ENCRYPTION_KEY define in wp-config.php is intentionally
+ * not touched: rewriting wp-config.php during uninstall risks truncating the
+ * site's bootstrap file, and a leftover define is inert. Remove it manually
+ * if desired.
  *
  * @package A8C\SpecialProjects\Atlantis
  */
@@ -17,11 +18,15 @@ defined( 'ABSPATH' ) || exit;
 defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
 
 /**
- * Removes the custom table and every option the plugin created.
+ * Removes the plugin's data from the current site.
+ *
+ * Runs for the requesting site on single-site installs, and once per site
+ * (via switch_to_blog) on multisite. $wpdb is re-resolved inside so the
+ * switched blog's prefix and options table are used.
  *
  * @return void
  */
-function a8csp_atlantis_uninstall_cleanup(): void {
+function a8csp_atlantis_uninstall_cleanup_single_site(): void {
 	global $wpdb;
 
 	// Drop the custom table created by the Messages module.
@@ -47,43 +52,27 @@ function a8csp_atlantis_uninstall_cleanup(): void {
 }
 
 /**
- * Strips the A8CSP_ATLANTIS_ENCRYPTION_KEY define from wp-config.php.
+ * Removes the custom table and every option the plugin created.
  *
- * Best effort only: it touches a file only when that file exists, is writable
- * and actually contains the define, so a site that never auto-inserted (or
- * manually pasted) the key is never rewritten.
+ * On multisite WordPress includes uninstall.php once for the whole network
+ * and never switches blog context around it, so every site is cleaned here.
  *
  * @return void
  */
-function a8csp_atlantis_uninstall_remove_encryption_key_define(): void {
-	$wp_config_candidates = array(
-		ABSPATH . 'wp-config.php',
-		dirname( ABSPATH ) . '/wp-config.php', // Typical "one level up" install.
-	);
+function a8csp_atlantis_uninstall_cleanup(): void {
+	// Network-level option written by the Autoupdates module's per-plugin filter.
+	delete_site_option( 'plugin_autoupdate_filter_disabled_plugins' );
 
-	foreach ( $wp_config_candidates as $wp_config_path ) {
-		if ( ! is_file( $wp_config_path ) || ! is_writable( $wp_config_path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
-			continue;
-		}
+	if ( ! is_multisite() ) {
+		a8csp_atlantis_uninstall_cleanup_single_site();
+		return;
+	}
 
-		$wp_config_contents = file_get_contents( $wp_config_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-		if ( false === $wp_config_contents || false === strpos( $wp_config_contents, 'A8CSP_ATLANTIS_ENCRYPTION_KEY' ) ) {
-			continue;
-		}
-
-		$cleaned_contents = preg_replace(
-			'~^[ \t]*define\(\s*[\'"]A8CSP_ATLANTIS_ENCRYPTION_KEY[\'"]\s*,.*\);\s*$~m',
-			'',
-			$wp_config_contents
-		);
-
-		if ( null !== $cleaned_contents && $cleaned_contents !== $wp_config_contents ) {
-			file_put_contents( $wp_config_path, $cleaned_contents ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-		}
-
-		break;
+	foreach ( get_sites( array( 'fields' => 'ids', 'number' => 0 ) ) as $site_id ) {
+		switch_to_blog( (int) $site_id );
+		a8csp_atlantis_uninstall_cleanup_single_site();
+		restore_current_blog();
 	}
 }
 
 a8csp_atlantis_uninstall_cleanup();
-a8csp_atlantis_uninstall_remove_encryption_key_define();

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Uninstall routine for the A8CSP Atlantis plugin.
+ *
+ * Fired when the plugin is deleted through the WordPress admin
+ * (Plugins -> Installed Plugins -> Delete). Removes everything the plugin
+ * created: the Messages custom table and every option it owns.
+ *
+ * The A8CSP_ATLANTIS_ENCRYPTION_KEY define is also stripped from wp-config.php
+ * on a best-effort basis. Whether uninstall should rewrite wp-config.php at all
+ * is the open question on the PR for https://github.com/a8cteam51/a8csp-atlantis/issues/80
+ *
+ * @package A8C\SpecialProjects\Atlantis
+ */
+
+defined( 'ABSPATH' ) || exit;
+defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
+
+/**
+ * Removes the custom table and every option the plugin created.
+ *
+ * @return void
+ */
+function a8csp_atlantis_uninstall_cleanup(): void {
+	global $wpdb;
+
+	// Drop the custom table created by the Messages module.
+	$table_name = $wpdb->prefix . 'a8csp_atlantis_messages';
+	$wpdb->query( "DROP TABLE IF EXISTS `{$table_name}`" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+	// Remove every option the plugin may have created on this site.
+	// Two prefixes cover Atlantis' own options and the per-module settings keys.
+	$option_names = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->prepare(
+			"SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s",
+			$wpdb->esc_like( 'a8csp_atlantis_' ) . '%',
+			$wpdb->esc_like( 'a8csp_module_' ) . '%'
+		)
+	);
+
+	foreach ( (array) $option_names as $option_name ) {
+		delete_option( $option_name );
+	}
+
+	// The Autoupdates module's delay option (also used by its predecessor plugin).
+	delete_option( 'plugin_update_delays' );
+}
+
+/**
+ * Strips the A8CSP_ATLANTIS_ENCRYPTION_KEY define from wp-config.php.
+ *
+ * Best effort only: it touches a file only when that file exists, is writable
+ * and actually contains the define, so a site that never auto-inserted (or
+ * manually pasted) the key is never rewritten.
+ *
+ * @return void
+ */
+function a8csp_atlantis_uninstall_remove_encryption_key_define(): void {
+	$wp_config_candidates = array(
+		ABSPATH . 'wp-config.php',
+		dirname( ABSPATH ) . '/wp-config.php', // Typical "one level up" install.
+	);
+
+	foreach ( $wp_config_candidates as $wp_config_path ) {
+		if ( ! is_file( $wp_config_path ) || ! is_writable( $wp_config_path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
+			continue;
+		}
+
+		$wp_config_contents = file_get_contents( $wp_config_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		if ( false === $wp_config_contents || false === strpos( $wp_config_contents, 'A8CSP_ATLANTIS_ENCRYPTION_KEY' ) ) {
+			continue;
+		}
+
+		$cleaned_contents = preg_replace(
+			'~^[ \t]*define\(\s*[\'"]A8CSP_ATLANTIS_ENCRYPTION_KEY[\'"]\s*,.*\);\s*$~m',
+			'',
+			$wp_config_contents
+		);
+
+		if ( null !== $cleaned_contents && $cleaned_contents !== $wp_config_contents ) {
+			file_put_contents( $wp_config_path, $cleaned_contents ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		}
+
+		break;
+	}
+}
+
+a8csp_atlantis_uninstall_cleanup();
+a8csp_atlantis_uninstall_remove_encryption_key_define();

--- a/uninstall.php
+++ b/uninstall.php
@@ -68,7 +68,14 @@ function a8csp_atlantis_uninstall_cleanup(): void {
 		return;
 	}
 
-	foreach ( get_sites( array( 'fields' => 'ids', 'number' => 0 ) ) as $site_id ) {
+	$site_ids = get_sites(
+		array(
+			'fields' => 'ids',
+			'number' => 0,
+		)
+	);
+
+	foreach ( $site_ids as $site_id ) {
 		switch_to_blog( (int) $site_id );
 		a8csp_atlantis_uninstall_cleanup_single_site();
 		restore_current_blog();


### PR DESCRIPTION
Closes #80.

## Summary

Deleting the plugin (Plugins → Installed Plugins → Delete) currently cleans up nothing: there is no `uninstall.php` and no `register_uninstall_hook()` anywhere, so the messages table, all options and the encryption-key define are left behind. This adds `uninstall.php`, which runs on delete and removes what the plugin created.

## What uninstall removes

- **Table:** drops `{$wpdb->prefix}a8csp_atlantis_messages`
- **Options:** every `a8csp_atlantis_*` and `a8csp_module_*` option (covers the encryption-key flag, the messages schema version, and the five per-module settings keys)
- **Option:** `plugin_update_delays`, deleted unconditionally — the legacy plugin-autoupdate-filter is treated as gone (it does write the same option name; that coexistence case is discussed on #80)
- **wp-config.php:** strips the `A8CSP_ATLANTIS_ENCRYPTION_KEY` define, best-effort and only when the define is actually present in the located config file

## Testing

- New integration test `tests/Integration/UninstallTestCest.php` seeds the table and all options, runs the uninstall routine the way WordPress does on delete, and asserts the table and every option are gone.
- Full Integration suite passes: 40 tests, 142 assertions.
- phpcs and phpmd clean on the new files.

## Open question — the wp-config.php rewrite

Per the scope discussion on #80 this is the part worth deciding before merge. Rewriting `wp-config.php` during uninstall is the same hazard #79 flagged (a non-atomic rewrite of the site's most critical file), and uninstall is the least recoverable moment to attempt it. Options:

1. **Keep the strip** (as written here). A leftover define is inert, but the write is non-atomic and it would remove a define an operator may have placed manually.
2. **Drop the strip from uninstall.** Leave the define in place and document removing it as a manual step.

The strip only touches the file when the define is present and the file is writable; on a site that never inserted the key it is a no-op.
