### PR TITLE
Reuse the last known good autoupdate settings and report fail-closed state

### DIFF
--- a/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
+++ b/src/Modules/Autoupdates/AutoUpdatePluginsFilter.php
@@ -27,6 +27,26 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 	 */
 	private \stdClass $settings;
 
+	/**
+	 * Option holding the last payload successfully fetched from OpsOasis.
+	 *
+	 * @since   1.3.1
+	 * @version 1.3.1
+	 *
+	 * @var string
+	 */
+	private const LAST_KNOWN_GOOD_OPTION = 'a8csp_atlantis_autoupdate_last_good_settings';
+
+	/**
+	 * Default centralized settings endpoint.
+	 *
+	 * @since   1.3.1
+	 * @version 1.3.1
+	 *
+	 * @var string
+	 */
+	private const DEFAULT_SETTINGS_URL = 'https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/autoupdate-plugin/v1/settings/';
+
 	// endregion
 
 	// region INHERITED METHODS
@@ -131,7 +151,8 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 	 * Load settings from the centralized settings page
 	 *
 	 * @throws  \RuntimeException If the settings cannot be loaded.
-	 * @throws  \JsonException    If the settings cannot be decoded.
+	 * @throws  \Exception        Rethrown when there is no usable last known good payload. Includes
+	 *                            the \JsonException raised when the response cannot be decoded.
 	 *
 	 * @return  \stdClass
 	 */
@@ -144,7 +165,7 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 		if ( empty( $settings ) ) {
 			try {
 				$response = wp_safe_remote_get(
-					'https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/autoupdate-plugin/v1/settings/',
+					self::get_settings_endpoint(),
 					array(
 						'timeout' => 2,
 						'headers' => array( 'Accept' => 'application/json' ),
@@ -175,9 +196,19 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 
 				// Save the settings in a transient for 5 minutes
 				set_transient( $transient_key, $decoded_body, 5 * MINUTE_IN_SECONDS );
+				self::store_last_known_good( $decoded_body );
 
 				$settings = $decoded_body;
 			} catch ( \Exception $exception ) {
+				// A short outage must not imitate a deliberate fleet-wide stop, so keep serving the last
+				// payload we fetched successfully. A stale `disabled_plugins` list still blocks whatever
+				// somebody deliberately blocked; only a newly added block is missed.
+				$last_known_good = self::get_last_known_good_settings();
+				if ( $last_known_good instanceof \stdClass ) {
+					set_transient( $transient_key, $last_known_good, 5 * MINUTE_IN_SECONDS );
+					return $last_known_good;
+				}
+
 				// Negative-cache the fail-safe so a slow/down OpsOasis cannot block every uncached page load.
 				set_transient( $transient_key, (object) array( 'disable_all' => true ), 5 * MINUTE_IN_SECONDS );
 				throw $exception;
@@ -185,6 +216,124 @@ class AutoUpdatePluginsFilter extends AbstractModule {
 		}
 
 		return $settings;
+	}
+
+	/**
+	 * Returns the centralized settings endpoint, overridable by constant or filter.
+	 *
+	 * @since   1.3.1
+	 * @version 1.3.1
+	 *
+	 * @return  string
+	 */
+	private static function get_settings_endpoint(): string {
+		$url = \defined( 'A8CSP_ATLANTIS_AUTOUPDATE_SETTINGS_URL' )
+			? (string) \constant( 'A8CSP_ATLANTIS_AUTOUPDATE_SETTINGS_URL' )
+			: self::DEFAULT_SETTINGS_URL;
+
+		/**
+		 * Filters the centralized autoupdate settings endpoint.
+		 *
+		 * @since 1.3.1
+		 *
+		 * @param string $url The settings endpoint URL.
+		 */
+		return (string) apply_filters( 'a8csp_atlantis_autoupdate_settings_url', $url );
+	}
+
+	/**
+	 * Returns how long the last known good settings may be reused while OpsOasis is unreachable.
+	 *
+	 * @since   1.3.1
+	 * @version 1.3.1
+	 *
+	 * @return  int
+	 */
+	private static function get_grace_period(): int {
+		/**
+		 * Filters the grace window for reusing the last known good autoupdate settings.
+		 *
+		 * @since 1.3.1
+		 *
+		 * @param int $grace Seconds since the last successful fetch. Default 24 hours.
+		 */
+		return (int) apply_filters( 'a8csp_atlantis_autoupdate_settings_grace', DAY_IN_SECONDS );
+	}
+
+	/**
+	 * Records a successfully fetched payload so it survives object-cache eviction.
+	 *
+	 * @since   1.3.1
+	 * @version 1.3.1
+	 *
+	 * @param   \stdClass $settings The payload to record.
+	 *
+	 * @return  void
+	 */
+	private static function store_last_known_good( \stdClass $settings ): void {
+		update_option(
+			self::LAST_KNOWN_GOOD_OPTION,
+			array(
+				'settings'  => $settings,
+				'timestamp' => time(),
+			),
+			false
+		);
+	}
+
+	/**
+	 * Returns the last known good payload, or null when there is none or it is past the grace window.
+	 *
+	 * @since   1.3.1
+	 * @version 1.3.1
+	 *
+	 * @return  \stdClass|null
+	 */
+	private static function get_last_known_good_settings(): ?\stdClass {
+		$stored = get_option( self::LAST_KNOWN_GOOD_OPTION );
+
+		if ( ! \is_array( $stored ) || ! isset( $stored['settings'], $stored['timestamp'] ) || ! \is_object( $stored['settings'] ) ) {
+			return null;
+		}
+
+		if ( ( time() - (int) $stored['timestamp'] ) >= self::get_grace_period() ) {
+			return null;
+		}
+
+		return $stored['settings'];
+	}
+
+	/**
+	 * Reports whether the site is currently refusing all autoupdates because the centralized
+	 * settings could not be fetched.
+	 *
+	 * Reads from storage rather than the module's own settings, because the REST status request
+	 * is not an autoupdate context and so never runs `initialize()`.
+	 *
+	 * @since   1.3.1
+	 * @version 1.3.1
+	 *
+	 * @return  array{fail_closed: bool, last_success: int|null, seconds_since_success: int|null}
+	 */
+	public static function get_settings_state(): array {
+		$stored = get_option( self::LAST_KNOWN_GOOD_OPTION );
+
+		if ( ! \is_array( $stored ) || ! isset( $stored['timestamp'] ) ) {
+			return array(
+				'fail_closed'           => true,
+				'last_success'          => null,
+				'seconds_since_success' => null,
+			);
+		}
+
+		$timestamp = (int) $stored['timestamp'];
+		$age       = time() - $timestamp;
+
+		return array(
+			'fail_closed'           => $age >= self::get_grace_period(),
+			'last_success'          => $timestamp,
+			'seconds_since_success' => $age,
+		);
 	}
 
 	/**

--- a/src/REST/Status_Controller.php
+++ b/src/REST/Status_Controller.php
@@ -113,10 +113,8 @@ class Status_Controller {
 			$modules['messages']['count'] = $this->count_messages();
 		}
 
-		// `enabled` only says the module is switched on. When the centralized settings cannot be
-		// fetched the module vetoes every plugin, theme and core update while still reporting
-		// enabled, so fleet tooling needs `fail_closed` to spot a prolonged outage.
-		if ( isset( $modules['autoupdates'] ) ) {
+		// A switched-off module never fetches, so it has nothing to report.
+		if ( isset( $modules['autoupdates'] ) && ! empty( $modules['autoupdates']['enabled'] ) ) {
 			$modules['autoupdates'] += AutoUpdatePluginsFilter::get_settings_state();
 		}
 

--- a/src/REST/Status_Controller.php
+++ b/src/REST/Status_Controller.php
@@ -3,6 +3,7 @@
 namespace A8C\SpecialProjects\Atlantis\REST;
 
 use A8C\SpecialProjects\Atlantis\Message_Query;
+use A8C\SpecialProjects\Atlantis\Modules\Autoupdates\AutoUpdatePluginsFilter;
 use A8C\SpecialProjects\Atlantis\Modules\BotProtection\BotProtection;
 use A8C\SpecialProjects\Atlantis\Modules\Messages\CustomTable;
 use A8C\SpecialProjects\Atlantis\Plugin;
@@ -110,6 +111,13 @@ class Status_Controller {
 
 		if ( isset( $modules['messages'] ) ) {
 			$modules['messages']['count'] = $this->count_messages();
+		}
+
+		// `enabled` only says the module is switched on. When the centralized settings cannot be
+		// fetched the module vetoes every plugin, theme and core update while still reporting
+		// enabled, so fleet tooling needs `fail_closed` to spot a prolonged outage.
+		if ( isset( $modules['autoupdates'] ) ) {
+			$modules['autoupdates'] += AutoUpdatePluginsFilter::get_settings_state();
 		}
 
 		// Bot Protection is mandatory, so its shared `enabled` flag (from

--- a/tests/Integration/AutoupdatesTestCest.php
+++ b/tests/Integration/AutoupdatesTestCest.php
@@ -344,6 +344,275 @@ class AutoupdatesTestCest {
 	}
 
 	/**
+	 * The settings endpoint must be overridable so a site can be pointed elsewhere.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function settings_endpoint_is_overridable( IntegrationTester $i ): void {
+		$this->reset_settings_storage();
+
+		$requested_url = null;
+		$capture       = static function ( $pre, $args, $url ) use ( &$requested_url ) {
+			$requested_url = $url;
+			return new WP_Error( 'http_request_failed', 'Captured.' );
+		};
+		$override = static function () {
+			return 'https://opsoasis.test/wp-json/wpcomsp/autoupdate-plugin/v1/settings/';
+		};
+
+		add_filter( 'a8csp_atlantis_autoupdate_settings_url', $override );
+		add_filter( 'pre_http_request', $capture, 10, 3 );
+
+		try {
+			$this->fetch_settings( new AutoUpdatePluginsFilter() );
+
+			Assert::assertSame(
+				'https://opsoasis.test/wp-json/wpcomsp/autoupdate-plugin/v1/settings/',
+				$requested_url,
+				'The settings request must use the filtered endpoint.'
+			);
+		} finally {
+			remove_filter( 'pre_http_request', $capture, 10 );
+			remove_filter( 'a8csp_atlantis_autoupdate_settings_url', $override );
+			$this->reset_settings_storage();
+		}
+	}
+
+	/**
+	 * A successful fetch must be recorded so it can be reused while the endpoint is unreachable.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function successful_fetch_records_last_known_good_settings( IntegrationTester $i ): void {
+		$this->reset_settings_storage();
+
+		$respond = $this->http_response( array( 'disabled_plugins' => array( 'akismet/akismet.php' ) ) );
+		add_filter( 'pre_http_request', $respond, 10, 3 );
+
+		try {
+			$settings = $this->fetch_settings( new AutoUpdatePluginsFilter() );
+
+			Assert::assertIsObject( $settings );
+			Assert::assertSame( array( 'akismet/akismet.php' ), (array) $settings->disabled_plugins );
+
+			$last_good = get_option( 'a8csp_atlantis_autoupdate_last_good_settings' );
+			Assert::assertIsArray( $last_good, 'A successful fetch must be recorded as the last known good settings.' );
+			Assert::assertArrayHasKey( 'settings', $last_good );
+			Assert::assertArrayHasKey( 'timestamp', $last_good );
+			Assert::assertGreaterThan( 0, $last_good['timestamp'] );
+		} finally {
+			remove_filter( 'pre_http_request', $respond, 10 );
+			$this->reset_settings_storage();
+		}
+	}
+
+	/**
+	 * A brief outage must reuse the last known good payload rather than stopping every update.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function failed_fetch_falls_back_to_last_known_good_within_grace( IntegrationTester $i ): void {
+		$this->reset_settings_storage();
+		$this->store_last_known_good(
+			array( 'disabled_plugins' => array( 'akismet/akismet.php' ) ),
+			time() - HOUR_IN_SECONDS
+		);
+
+		$fail = static function () {
+			return new WP_Error( 'http_request_failed', 'Simulated OpsOasis outage' );
+		};
+		add_filter( 'pre_http_request', $fail, 10, 3 );
+
+		try {
+			$settings = $this->fetch_settings( new AutoUpdatePluginsFilter() );
+
+			Assert::assertIsObject( $settings, 'A recent last known good payload must be used instead of failing closed.' );
+			Assert::assertTrue( empty( $settings->disable_all ), 'A brief outage must not disable every autoupdate.' );
+			Assert::assertSame(
+				array( 'akismet/akismet.php' ),
+				(array) $settings->disabled_plugins,
+				'Deliberate blocks must still be honoured while serving stale settings.'
+			);
+		} finally {
+			remove_filter( 'pre_http_request', $fail, 10 );
+			$this->reset_settings_storage();
+		}
+	}
+
+	/**
+	 * A prolonged outage must still end in the conservative state.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function failed_fetch_falls_closed_once_the_grace_period_expires( IntegrationTester $i ): void {
+		$this->reset_settings_storage();
+		$this->store_last_known_good(
+			array( 'disabled_plugins' => array() ),
+			time() - ( 25 * HOUR_IN_SECONDS )
+		);
+
+		$fail = static function () {
+			return new WP_Error( 'http_request_failed', 'Simulated OpsOasis outage' );
+		};
+		add_filter( 'pre_http_request', $fail, 10, 3 );
+
+		try {
+			$settings = $this->fetch_settings( new AutoUpdatePluginsFilter() );
+
+			Assert::assertNull( $settings, 'An expired last known good payload must surface an exception to the caller.' );
+
+			$cached = get_transient( 'wpcpmsp_auto_update_settings' );
+			Assert::assertIsObject( $cached );
+			Assert::assertTrue( ! empty( $cached->disable_all ), 'The fail-safe must still be negative-cached.' );
+		} finally {
+			remove_filter( 'pre_http_request', $fail, 10 );
+			$this->reset_settings_storage();
+		}
+	}
+
+	/**
+	 * The grace window must be adjustable without a code change.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function grace_period_is_filterable( IntegrationTester $i ): void {
+		$this->reset_settings_storage();
+		$this->store_last_known_good( array( 'disabled_plugins' => array() ), time() );
+
+		$no_grace = static function () {
+			return 0;
+		};
+		$fail = static function () {
+			return new WP_Error( 'http_request_failed', 'Simulated OpsOasis outage' );
+		};
+
+		add_filter( 'a8csp_atlantis_autoupdate_settings_grace', $no_grace );
+		add_filter( 'pre_http_request', $fail, 10, 3 );
+
+		try {
+			$settings = $this->fetch_settings( new AutoUpdatePluginsFilter() );
+
+			Assert::assertNull( $settings, 'A zero grace window must fail closed immediately.' );
+		} finally {
+			remove_filter( 'pre_http_request', $fail, 10 );
+			remove_filter( 'a8csp_atlantis_autoupdate_settings_grace', $no_grace );
+			$this->reset_settings_storage();
+		}
+	}
+
+	/**
+	 * The fail-closed state must be readable from storage, because the REST status request
+	 * is not an autoupdate context and so never populates the module's settings property.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function settings_state_is_readable_without_initializing_the_module( IntegrationTester $i ): void {
+		$this->reset_settings_storage();
+
+		$state = AutoUpdatePluginsFilter::get_settings_state();
+
+		Assert::assertTrue( $state['fail_closed'], 'With nothing stored, the site is fail-closed.' );
+		Assert::assertNull( $state['last_success'] );
+		Assert::assertNull( $state['seconds_since_success'] );
+
+		$this->store_last_known_good( array( 'disabled_plugins' => array() ), time() - HOUR_IN_SECONDS );
+
+		$state = AutoUpdatePluginsFilter::get_settings_state();
+
+		Assert::assertFalse( $state['fail_closed'], 'A last known good payload inside the grace window is not fail-closed.' );
+		Assert::assertIsInt( $state['last_success'] );
+		Assert::assertGreaterThanOrEqual( HOUR_IN_SECONDS, $state['seconds_since_success'] );
+
+		$this->store_last_known_good( array( 'disabled_plugins' => array() ), time() - ( 25 * HOUR_IN_SECONDS ) );
+
+		$state = AutoUpdatePluginsFilter::get_settings_state();
+
+		Assert::assertTrue( $state['fail_closed'], 'A last known good payload older than the grace window is fail-closed.' );
+
+		$this->reset_settings_storage();
+	}
+
+	/**
+	 * Invokes the private settings fetch, returning null when it throws.
+	 *
+	 * @param AutoUpdatePluginsFilter $module Module instance.
+	 *
+	 * @return \stdClass|null
+	 */
+	private function fetch_settings( AutoUpdatePluginsFilter $module ): ?\stdClass {
+		$method = new ReflectionMethod( $module, 'get_auto_update_settings' );
+		$method->setAccessible( true );
+
+		try {
+			return $method->invoke( $module );
+		} catch ( \Exception $exception ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Builds a `pre_http_request` callback returning a successful JSON response.
+	 *
+	 * @param array $payload Response payload.
+	 *
+	 * @return callable
+	 */
+	private function http_response( array $payload ): callable {
+		return static function () use ( $payload ) {
+			return array(
+				'headers'  => array(),
+				'body'     => (string) wp_json_encode( $payload ),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+	}
+
+	/**
+	 * Seeds the last known good settings option.
+	 *
+	 * @param array $payload   Settings payload.
+	 * @param int   $timestamp When the payload was last fetched successfully.
+	 *
+	 * @return void
+	 */
+	private function store_last_known_good( array $payload, int $timestamp ): void {
+		update_option(
+			'a8csp_atlantis_autoupdate_last_good_settings',
+			array(
+				'settings'  => (object) $payload,
+				'timestamp' => $timestamp,
+			)
+		);
+	}
+
+	/**
+	 * Clears both the settings transient and the last known good option.
+	 *
+	 * @return void
+	 */
+	private function reset_settings_storage(): void {
+		delete_transient( 'wpcpmsp_auto_update_settings' );
+		delete_option( 'a8csp_atlantis_autoupdate_last_good_settings' );
+	}
+
+	/**
 	 * Set current user as admin to satisfy capability checks.
 	 *
 	 * @return void

--- a/tests/Integration/StatusControllerTestCest.php
+++ b/tests/Integration/StatusControllerTestCest.php
@@ -51,6 +51,43 @@ class StatusControllerTestCest {
 	}
 
 	/**
+	 * A switched-off module vetoes nothing, so it must not answer the "is this site refusing
+	 * updates?" question at all. It never fetches, so it has no successful fetch on record and
+	 * would otherwise report itself as permanently fail-closed.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function status_payload_omits_autoupdate_state_when_the_module_is_off( IntegrationTester $i ): void {
+		$option_key = a8csp_atlantis_generate_module_settings_key( 'Autoupdates' );
+		$previous   = get_option( $option_key, array() );
+
+		delete_option( 'a8csp_atlantis_autoupdate_last_good_settings' );
+
+		try {
+			update_option( $option_key, array( 'enabled' => '0' ) );
+
+			$modules = $this->get_modules_payload();
+
+			Assert::assertFalse( $modules['autoupdates']['enabled'], 'Test precondition: the module is switched off.' );
+			Assert::assertArrayNotHasKey( 'fail_closed', $modules['autoupdates'] );
+			Assert::assertArrayNotHasKey( 'last_success', $modules['autoupdates'] );
+			Assert::assertArrayNotHasKey( 'seconds_since_success', $modules['autoupdates'] );
+
+			update_option( $option_key, array( 'enabled' => '1' ) );
+
+			$modules = $this->get_modules_payload();
+
+			Assert::assertTrue( $modules['autoupdates']['enabled'], 'Test precondition: the module is switched on.' );
+			Assert::assertArrayHasKey( 'fail_closed', $modules['autoupdates'], 'A running module must still report its state.' );
+		} finally {
+			update_option( $option_key, $previous );
+			delete_option( 'a8csp_atlantis_autoupdate_last_good_settings' );
+		}
+	}
+
+	/**
 	 * Returns the `modules` section of the status payload.
 	 *
 	 * @return array

--- a/tests/Integration/StatusControllerTestCest.php
+++ b/tests/Integration/StatusControllerTestCest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Integration tests for the REST status payload.
+ */
+
+declare(strict_types=1);
+
+use A8C\SpecialProjects\Atlantis\REST\Status_Controller;
+use PHPUnit\Framework\Assert;
+use Tests\Support\IntegrationTester;
+
+/**
+ * Status controller integration tests.
+ */
+class StatusControllerTestCest {
+	/**
+	 * The autoupdates entry must report whether the site is currently refusing all updates,
+	 * because `enabled` stays true throughout an OpsOasis outage.
+	 *
+	 * @param IntegrationTester $i Tester instance.
+	 *
+	 * @return void
+	 */
+	public function status_payload_reports_the_autoupdates_fail_closed_state( IntegrationTester $i ): void {
+		delete_option( 'a8csp_atlantis_autoupdate_last_good_settings' );
+
+		$modules = $this->get_modules_payload();
+
+		Assert::assertArrayHasKey( 'autoupdates', $modules, 'The autoupdates module must appear in the status payload.' );
+		Assert::assertTrue( $modules['autoupdates']['fail_closed'], 'With no successful fetch on record the site is fail-closed.' );
+		Assert::assertNull( $modules['autoupdates']['last_success'] );
+
+		update_option(
+			'a8csp_atlantis_autoupdate_last_good_settings',
+			array(
+				'settings'  => (object) array( 'disabled_plugins' => array() ),
+				'timestamp' => time() - HOUR_IN_SECONDS,
+			)
+		);
+
+		$modules = $this->get_modules_payload();
+
+		Assert::assertFalse( $modules['autoupdates']['fail_closed'], 'A recent successful fetch is not fail-closed.' );
+		Assert::assertIsInt( $modules['autoupdates']['last_success'] );
+		Assert::assertGreaterThanOrEqual( HOUR_IN_SECONDS, $modules['autoupdates']['seconds_since_success'] );
+
+		// `enabled` must remain true in both states — that is precisely why `fail_closed` is needed.
+		Assert::assertTrue( $modules['autoupdates']['enabled'] );
+
+		delete_option( 'a8csp_atlantis_autoupdate_last_good_settings' );
+	}
+
+	/**
+	 * Returns the `modules` section of the status payload.
+	 *
+	 * @return array
+	 */
+	private function get_modules_payload(): array {
+		$controller = new Status_Controller();
+		$response   = $controller->get_item( new WP_REST_Request( 'GET', '/a8csp-atlantis/v1/status' ) );
+		$data       = $response->get_data();
+
+		Assert::assertArrayHasKey( 'modules', $data );
+
+		return $data['modules'];
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Addresses #82 and #78 together, because they are the same code path: #78 changes what happens during an outage, and #82 makes that state visible from outside the site.

**Last known good settings, with a bounded grace (#78)**

* Every successful fetch is now recorded in a new option, `a8csp_atlantis_autoupdate_last_good_settings`, holding the payload and the time it was fetched. An option rather than only a transient, so it survives object-cache eviction — which is exactly when it is needed.
* On a failed fetch, `get_auto_update_settings()` serves that payload instead of `disable_all => true`, and returns normally rather than throwing.
* It falls closed only once the last success is older than a grace window — 24 hours by default, adjustable with the new `a8csp_atlantis_autoupdate_settings_grace` filter. A prolonged outage still ends in the conservative state.
* `disable_all` is untouched and remains the explicit way to stop the fleet. An availability failure no longer has to imitate it.

Serving stale settings is conservative in the direction that matters: a stale `disabled_plugins` list still blocks whatever somebody deliberately blocked. Only a *newly added* block is missed during the window — against which the previous behaviour blocked everything, security updates included.

**Fail-closed state in the status payload (#82)**

* `modules.autoupdates` in the REST status response gains `fail_closed`, `last_success` and `seconds_since_success`.
* These are derived from stored data via a new `AutoUpdatePluginsFilter::get_settings_state()`, not from the module's `$settings` property. That matters: a REST request is not an autoupdate context, so `initialize()` returns early and `$settings` is never set. Reading the instance would have reported nothing.
* `enabled` deliberately still reports `true` throughout an outage — that is accurate, and it is precisely why a separate signal was needed. There is a test asserting both at once.

**Endpoint override (#82)**

* The hardcoded OpsOasis URL moves behind `AutoUpdatePluginsFilter::get_settings_endpoint()`, overridable by the `A8CSP_ATLANTIS_AUTOUPDATE_SETTINGS_URL` constant or the `a8csp_atlantis_autoupdate_settings_url` filter. This is also what makes the fetch stubbable, and several of the new tests depend on it.

#### Testing instructions

```bash
npm run tests:run:integration   # 46 tests, 161 assertions
```

Seven new tests, six in `AutoupdatesTestCest` and one in a new `StatusControllerTestCest`:

| Test | Asserts |
| --- | --- |
| `settings_endpoint_is_overridable` | the request goes to the filtered URL |
| `successful_fetch_records_last_known_good_settings` | a success writes the option |
| `failed_fetch_falls_back_to_last_known_good_within_grace` | an outage keeps the stored blocks and does not set `disable_all` |
| `failed_fetch_falls_closed_once_the_grace_period_expires` | past the window, the fail-safe is negative-cached as before |
| `grace_period_is_filterable` | a zero window fails closed immediately |
| `settings_state_is_readable_without_initializing_the_module` | state is correct with nothing stored, inside the window, and past it |
| `status_payload_reports_the_autoupdates_fail_closed_state` | the REST payload carries the keys, and `enabled` stays true in both states |

Manual check:

1. Point the site at a dead endpoint: `add_filter( 'a8csp_atlantis_autoupdate_settings_url', fn() => 'https://127.0.0.1/nope' );`
2. Load wp-admin once with a good endpoint first so a last known good payload is recorded, then switch to the dead one.
3. Request `/wp-json/a8csp-atlantis/v1/status` as an administrator. `modules.autoupdates.fail_closed` is `false` while inside the grace window; autoupdates continue to be evaluated normally.
4. Set `add_filter( 'a8csp_atlantis_autoupdate_settings_grace', fn() => 0 );` and request it again. `fail_closed` is now `true`.

#### Notes

* **Behaviour change worth flagging:** during the grace window the fetch now succeeds, so the "Unable to get autoupdate settings" admin notice no longer appears for brief outages. That is the intended effect — the local signal goes quiet while the remote one becomes accurate — but it is a visible difference for anyone used to seeing that notice.
* The `wpcpmsp_auto_update_settings` transient key is deliberately left alone.
* #78's other note, about retiring the predecessor plugin on sites still running it, is out of scope here — it concerns a different plugin.
* `phpcs` is clean. This PR also adds the `@throws` tag that `phpcs` was already failing on for this file on `trunk`.
* `phpmd` reports 13 violations and `phpstan` 10 errors, all pre-existing and none in the files touched here — they are in `src/CLI/*`, `PluginFilterRules.php`, `ListTable.php`, `Bilmur.php`, `Plugin.php` and `Force_Update_Check_Controller.php`.
* The `EndToEnd` suite contains no tests, only a bootstrap, so there was nothing to run there.

Fixes #82
Fixes #78
